### PR TITLE
Improved speed of FasterPath.chop_basename again

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Current methods implemented:
 |FasterPath Rust Implementation|Ruby 2.3.1 Implementation|Performance Improvement|
 |---|---|:---:|
 | `FasterPath.absolute?` | `Pathname#absolute?` | 1234.6% |
-| `FasterPath.chop_basename` | `Pathname#chop_basename` | 27.5% |
+| `FasterPath.chop_basename` | `Pathname#chop_basename` | 46.7% |
 | `FasterPath.relative?` | `Pathname#relative?` | 1262.3% |
 | `FasterPath.blank?` | | |
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,7 +23,7 @@ fn rust_to_ruby_c_char_convenient(b: &mut Bencher){
 
 // SANCTIONED USAGE
 #[bench]
-fn rust_to_ruby_to_c_char(b: &mut Bencher){
+fn rust_to_ruby_c_char(b: &mut Bencher){
   let s: String = "hello".to_string();
   let s = s.as_str();
 

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -18,11 +18,7 @@ module FasterPath
   # to handle non-path strings.
   def self.chop_basename(pth)
     d,b = [Rust.dirname(pth), Rust.basename(pth)]
-    if blank?(d) && blank?(b)
-      nil
-    else
-      [d,b]
-    end
+    [d,b] unless Rust.both_are_blank(d,b)
   end
 
   def self.blank?(str)
@@ -54,6 +50,7 @@ module FasterPath
     attach_function :is_absolute, [ :string ], :bool
     attach_function :is_relative, [ :string ], :bool
     attach_function :is_blank, [ :string ], :bool
+    attach_function :both_are_blank, [ :string, :string ], :bool
     attach_function :basename, [ :string ], :string
     attach_function :dirname, [ :string ], :string
 

--- a/src/both_are_blank.rs
+++ b/src/both_are_blank.rs
@@ -1,0 +1,14 @@
+#[no_mangle]
+pub extern fn both_are_blank(s1: *const c_char, s2: *const c_char) -> bool {
+  let c_str1 = unsafe {
+    assert!(!s1.is_null());
+    CStr::from_ptr(s1)
+  };
+  let c_str2 = unsafe {
+    assert!(!s2.is_null());
+    CStr::from_ptr(s2)
+  };
+
+  str::from_utf8(c_str1.to_bytes()).unwrap().trim().is_empty() &&
+    str::from_utf8(c_str2.to_bytes()).unwrap().trim().is_empty()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ include!("ruby_array.rs");
 include!("is_absolute.rs");
 include!("is_relative.rs");
 include!("is_blank.rs");
+include!("both_are_blank.rs");
 include!("basename.rs");
 include!("dirname.rs");
 

--- a/src/ruby_array.rs
+++ b/src/ruby_array.rs
@@ -5,6 +5,7 @@ pub struct RubyArray {
 }
 
 impl RubyArray {
+  #[allow(dead_code)]
   fn from_vec<T>(vec: Vec<T>) -> RubyArray {
     let array = RubyArray { 
       data: vec.as_ptr() as *const libc::c_void, 

--- a/src/ruby_string.rs
+++ b/src/ruby_string.rs
@@ -8,6 +8,7 @@ pub struct RubyString;
 // gain regardless.  But really consider not using String.  If you do
 // as I've intstructed the performance gains will go from 900% to 1250%.
 impl RubyString {
+  #[allow(dead_code)]
   // FOR QUICK IMPLEMENTATION.  NOT FOR PRODUCTION.
   // SEE BENCHMARKS FOR SANCTIONED IMPLEMENTATION.
   fn from_ruby(s: *const c_char) -> String {
@@ -18,6 +19,7 @@ impl RubyString {
     (*str::from_utf8(c_str.to_bytes()).unwrap_or("")).to_string()
   }
 
+  #[allow(dead_code)]
   // FOR QUICK IMPLEMENTATION.  NOT FOR PRODUCTION.
   // SEE BENCHMARKS FOR SANCTIONED IMPLEMENTATION.
   fn to_ruby<S: Into<String>>(s: S) -> *const c_char {

--- a/test/benches/chop_basename_benchmark.rb
+++ b/test/benches/chop_basename_benchmark.rb
@@ -5,7 +5,7 @@ require "pathname"
 class FasterPathBenchmark < Minitest::Benchmark
   def bench_rust_chop_basename
     assert_performance_constant do |n|
-      5000.times do
+      100000.times do
         FasterPath.chop_basename "/hello/world.txt"
         FasterPath.chop_basename "world.txt"
         FasterPath.chop_basename ""
@@ -15,7 +15,7 @@ class FasterPathBenchmark < Minitest::Benchmark
 
   def bench_ruby_chop_basename
     assert_performance_constant do |n|
-      5000.times do
+      100000.times do
         Pathname.new("").send :chop_basename, "/hello/world.txt"
         Pathname.new("").send :chop_basename, "world.txt"
         Pathname.new("").send :chop_basename, ""


### PR DESCRIPTION
An additional 19.2% performance gain has been added to
`FasterPath.chop_basename`.  This is the most called method in Rails
apps that I've seen.  With it's previous improvement of 27.5% my Rails
application performance improved by 15%.  So this is a huge performance
gain!

I've added more iterations to the benchmark test to try and get the
numbers tighter for more accurate benchmarks.

closes #5