### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Pathname#exist? called 152 times.
 Pathname#sub called 142 times.
 ```
 
-After digging further I've found that Pathname is heavily used in Sprockets 2 but in Sprockets 3 they switched to calling Ruby's faster methods from `File#initialize` and `Dir#each`.  It appears they've written all of the path handling on top of these themselves in Ruby.  They achieved some performance gain by switching to rawer code methods, but then they lost more than that inperformance by the **many** method calls built on top of that.
+After digging further I've found that Pathname is heavily used in Sprockets 2 but in Sprockets 3 they switched to calling Ruby's faster methods from `File#initialize` and `Dir#each`.  It appears they've written all of the path handling on top of these themselves in Ruby.  They achieved some performance gain by switching to rawer code methods, but then they lost more than that in performance by the **many** method calls built on top of that.
 
 If you want to see the best results in Rails with this gem you will likely need to be using the Sprockets 2.0 series.  Otherwise this library would need to rewrite Sprockets itself.
 


### PR DESCRIPTION
Fix typo "inperformance" to "in performance"