### PR TITLE
Switch from system to %x for running rake in ext/faster_path/extconf.rb

### DIFF
--- a/ext/faster_path/extconf.rb
+++ b/ext/faster_path/extconf.rb
@@ -12,8 +12,8 @@ unless find_executable('cargo')
 end
 
 Dir.chdir(File.expand_path("../../", File.dirname(__FILE__))) do
-  system("rake build_src")
-  system("rake clean_src")
+  %x(rake build_src)
+  %x(rake clean_src)
 end
 
 create_makefile('faster_path/dummy')


### PR DESCRIPTION
Not sure if this fixes it for mac users, but I was having issues with getting this gem to install extensions inside a docker container running Debian Jessie. Switch to %x fixed it. Maybe something todo with waiting for output?

https://stackoverflow.com/questions/6338908/ruby-difference-between-exec-system-and-x-or-backticks