### PR TITLE
Remove usage of include! macro

### DIFF
--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,3 +1,8 @@
+use std::path::MAIN_SEPARATOR;
+use libc::c_char;
+use std::ffi::{CStr,CString};
+use std::str;
+
 #[allow(dead_code)]
 fn rubyish_basename(string: &str, globish_string: &str) -> String {
   let result = if globish_string == ".*" {

--- a/src/basename_for_chop.rs
+++ b/src/basename_for_chop.rs
@@ -1,3 +1,8 @@
+use std::path::MAIN_SEPARATOR;
+use libc::c_char;
+use std::ffi::{CStr,CString};
+use std::str;
+
 #[no_mangle]
 pub extern fn basename_for_chop(string: *const c_char) -> *const c_char {
   let c_str = unsafe {

--- a/src/both_are_blank.rs
+++ b/src/both_are_blank.rs
@@ -1,3 +1,7 @@
+use libc::c_char;
+use std::ffi::{CStr};
+use std::str;
+
 #[no_mangle]
 pub extern fn both_are_blank(s1: *const c_char, s2: *const c_char) -> bool {
   let c_str1 = unsafe {

--- a/src/dirname.rs
+++ b/src/dirname.rs
@@ -1,3 +1,8 @@
+use std::path::{Path,MAIN_SEPARATOR};
+use libc::c_char;
+use std::ffi::{CStr,CString};
+use std::str;
+
 #[no_mangle]
 pub extern fn dirname(string: *const c_char) -> *const c_char {
   let c_str = unsafe {

--- a/src/dirname_for_chop.rs
+++ b/src/dirname_for_chop.rs
@@ -1,3 +1,8 @@
+use std::path::MAIN_SEPARATOR;
+use libc::c_char;
+use std::ffi::{CStr,CString};
+use std::str;
+
 #[no_mangle]
 pub extern fn dirname_for_chop(string: *const c_char) -> *const c_char {
   let c_str = unsafe {

--- a/src/is_absolute.rs
+++ b/src/is_absolute.rs
@@ -1,3 +1,9 @@
+use libc::c_char;
+use std::ffi::{CStr};
+use std::str;
+use std::path::MAIN_SEPARATOR;
+
+
 #[no_mangle]
 pub extern fn is_absolute(string: *const c_char) -> bool {
   let c_str = unsafe {

--- a/src/is_blank.rs
+++ b/src/is_blank.rs
@@ -1,3 +1,7 @@
+use libc::c_char;
+use std::ffi::{CStr};
+use std::str;
+
 #[no_mangle]
 pub extern fn is_blank(string: *const c_char) -> bool {
   let c_str = unsafe {

--- a/src/is_relative.rs
+++ b/src/is_relative.rs
@@ -1,3 +1,8 @@
+use std::path::MAIN_SEPARATOR;
+use libc::c_char;
+use std::ffi::{CStr};
+use std::str;
+
 #[no_mangle]
 pub extern fn is_relative(string: *const c_char) -> bool {
   let c_str = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,22 +6,16 @@
 // copied, modified, or distributed except according to those terms.
 extern crate libc;
 
-use std::path::{Path,MAIN_SEPARATOR};
-use libc::c_char;
-use std::ffi::{CStr,CString};
-use std::str;
-use std::mem;
-
-include!("ruby_string.rs");
-include!("ruby_array.rs");
-include!("is_absolute.rs");
-include!("is_relative.rs");
-include!("is_blank.rs");
-include!("both_are_blank.rs");
-include!("basename.rs");
-include!("dirname.rs");
-include!("basename_for_chop.rs");
-include!("dirname_for_chop.rs");
+pub mod ruby_string;
+pub mod ruby_array;
+pub mod is_absolute;
+pub mod is_relative;
+pub mod is_blank;
+pub mod both_are_blank;
+pub mod basename;
+pub mod dirname;
+pub mod basename_for_chop;
+pub mod dirname_for_chop;
 
 // EXAMPLE
 //

--- a/src/ruby_array.rs
+++ b/src/ruby_array.rs
@@ -1,3 +1,6 @@
+use libc;
+use std::mem;
+
 #[repr(C)]
 pub struct RubyArray {
   len: libc::size_t,

--- a/src/ruby_string.rs
+++ b/src/ruby_string.rs
@@ -1,3 +1,7 @@
+use libc::c_char;
+use std::ffi::{CStr,CString};
+use std::str;
+
 pub struct RubyString;
 
 // Coercing strs into Strings has some loss of performance


### PR DESCRIPTION
std::include! is documented as ["this is generally a bad idea"](https://doc.rust-lang.org/std/macro.include!.html), mostly due to hygiene reasons. It's also unnecessary in this case, as Rust will happily export those symbols the way you want.

This patch removes the usage of include! and makes the files more self-contained, declaring their actual dependencies.

Weirdly though, I've hit a compiler bug in the process, you need to run `cargo test --release`, otherwise, the code won't compile in test mode. `cargo build --release` works fine.