### PR TITLE
Installing Rust via rustup.sh doesn't require sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Ensure Rust is installed:
 [Rust Downloads](https://www.rust-lang.org/downloads.html)
 
 ```
-curl -sSf https://static.rust-lang.org/rustup.sh | sudo sh -s -- --channel=stable
+curl -sSf https://static.rust-lang.org/rustup.sh | sh
 ```
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
The line to install Rust includes sudo, but this is unnecessary. I've changed that line to exactly match the installation command given on rust-lang.org. This also involves removing the `-s -- channel=stable`, since this is implied by default.