### PR TITLE
Add FasterPath.add_trailing_separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Current methods implemented:
 | `FasterPath.relative?` | `Pathname#relative?` | 1262.3% |
 | `FasterPath.blank?` | | |
 | `FasterPath.directory?` | `Pathname#directory?` | 20% |
+| `FasterPath.add_trailing_separator | `Pathname.add_trailing_separator` | 63.8% |
 
 You may choose to use the methods directly, or scope change to rewrite behavior on the
 standard library with the included refinements, or even call a method to monkeypatch 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Current methods implemented:
 | `FasterPath.relative?` | `Pathname#relative?` | 1262.3% |
 | `FasterPath.blank?` | | |
 | `FasterPath.directory?` | `Pathname#directory?` | 20% |
-| `FasterPath.add_trailing_separator | `Pathname.add_trailing_separator` | 63.8% |
+| `FasterPath.add_trailing_separator | `Pathname#add_trailing_separator` | 63.8% |
 
 You may choose to use the methods directly, or scope change to rewrite behavior on the
 standard library with the included refinements, or even call a method to monkeypatch 

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -35,6 +35,10 @@ module FasterPath
     Rust.basename(pth, ext)
   end 
 
+  def self.add_trailing_separator(pth)
+    Rust.add_trailing_separator(pth)
+  end
+
   # EXAMPLE
   #def self.one_and_two
   #  Rust.one_and_two.to_a
@@ -66,6 +70,7 @@ module FasterPath
     attach_function :dirname, [ :string ], :string
     attach_function :basename_for_chop, [ :string ], :string # decoupling behavior
     attach_function :dirname_for_chop, [ :string ], :string # decoupling behavior
+    attach_function :add_trailing_separator, [ :string ], :string
 
     # EXAMPLE
     #attach_function :one_and_two, [], FromRustArray.by_value

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -23,6 +23,11 @@ module FasterPath
       def relative?
         FasterPath.relative?(@path)
       end
+
+     def add_trailing_separator(pth)
+        FasterPath.add_trailing_separator(pth)
+     end
+     private :add_trailing_separator
     end
   end
 end

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -25,6 +25,11 @@ module FasterPath
       def relative?
         FasterPath.relative?(@path)
       end
+
+      def add_trailing_separator(pth)
+        FasterPath.add_trailing_separator(pth)
+      end
+      private :add_trailing_separator
     end
   end
 end

--- a/src/add_trailing_separator.rs
+++ b/src/add_trailing_separator.rs
@@ -1,0 +1,28 @@
+use std::path::{Path, MAIN_SEPARATOR};
+use libc::c_char;
+use std::ffi::{CStr, CString};
+use std::str;
+
+#[no_mangle]
+pub extern "C" fn add_trailing_separator(string: *const c_char) -> *const c_char {
+    let c_str = unsafe {
+        assert!(!string.is_null());
+
+        CStr::from_ptr(string)
+    };
+    let r_str = str::from_utf8(c_str.to_bytes()).unwrap_or("");
+
+    if r_str.is_empty() {
+        return string;
+    }
+
+    let path = Path::new(r_str);
+    let out_str = if !(path.to_str().unwrap().chars().last().unwrap() == '/') {
+        format!("{}{}", path.to_str().unwrap(), MAIN_SEPARATOR)
+    } else {
+        path.to_str().unwrap().to_string()
+    };
+
+    let output = CString::new(out_str).unwrap();
+    output.into_raw()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod basename;
 pub mod dirname;
 pub mod basename_for_chop;
 pub mod dirname_for_chop;
+pub mod add_trailing_separator;
 
 // EXAMPLE
 //

--- a/test/add_trailing_separator_test.rb
+++ b/test/add_trailing_separator_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AddTrailingSeparatorTest < Minitest::Test
+  def test_add_trailing_separator
+    assert_equal FasterPath.add_trailing_separator(''), ''
+    assert_equal FasterPath.add_trailing_separator('/'), '/'
+    assert_equal FasterPath.add_trailing_separator('//'), '//'
+    assert_equal FasterPath.add_trailing_separator('hello'), 'hello/'
+    assert_equal FasterPath.add_trailing_separator('hello/'), 'hello/'
+    assert_equal FasterPath.add_trailing_separator('/hello/'), '/hello/'
+    assert_equal FasterPath.add_trailing_separator('/hello//'), '/hello//'
+    assert_equal FasterPath.add_trailing_separator('.'), './'
+    assert_equal FasterPath.add_trailing_separator('./'), './'
+    assert_equal FasterPath.add_trailing_separator('.//'), './/'
+  end
+
+  def test_add_trailing_separator_in_dosish_context
+    if File.dirname('A:') == 'A:.'
+      assert_equal FasterPath.add_trailing_separator('A:'), 'A:/'
+      assert_equal FasterPath.add_trailing_separator('A:/'), 'A:/'
+      assert_equal FasterPath.add_trailing_separator('A://'), 'A://'
+      assert_equal FasterPath.add_trailing_separator('A:.'), 'A:./'
+      assert_equal FasterPath.add_trailing_separator('A:./'), 'A:./'
+      assert_equal FasterPath.add_trailing_separator('A:.//'), 'A:.//'
+    end
+  end
+end

--- a/test/add_trailing_separator_test.rb
+++ b/test/add_trailing_separator_test.rb
@@ -24,4 +24,54 @@ class AddTrailingSeparatorTest < Minitest::Test
       assert_equal FasterPath.add_trailing_separator('A:.//'), 'A:.//'
     end
   end
+
+  def test_add_trailing_separator_against_pathname_implementation
+    result_pair = -> (str) {
+      [
+        Pathname.allocate.send(:add_trailing_separator, str),
+        FasterPath.add_trailing_separator(str)
+      ]
+    }
+
+    assert_equal(*result_pair.(''))
+    assert_equal(*result_pair.('/'))
+    assert_equal(*result_pair.('//'))
+    assert_equal(*result_pair.('hello'))
+    assert_equal(*result_pair.('hello/'))
+    assert_equal(*result_pair.('/hello/'))
+    assert_equal(*result_pair.('/hello//'))
+    assert_equal(*result_pair.('.'))
+    assert_equal(*result_pair.('./'))
+    assert_equal(*result_pair.('.//'))
+    assert_equal(*result_pair.("aa/a//a"))
+    assert_equal(*result_pair.("/aaa/a//a"))
+    assert_equal(*result_pair.("/aaa/a//a/a"))
+    assert_equal(*result_pair.("/aaa/a//a/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa"))
+    assert_equal(*result_pair.("/aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa////"))
+    assert_equal(*result_pair.("a/a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("////a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("////a//aaa/a//a/aaa////"))
+    assert_equal(*result_pair.("."))
+    assert_equal(*result_pair.(".././"))
+    assert_equal(*result_pair.(".///.."))
+    assert_equal(*result_pair.("/././/"))
+    assert_equal(*result_pair.("//../././"))
+    assert_equal(*result_pair.(".///.../.."))
+    assert_equal(*result_pair.("/././/.//."))
+    assert_equal(*result_pair.("/...//../././"))
+    assert_equal(*result_pair.("/..///.../..//"))
+    assert_equal(*result_pair.("/./././/.//..."))
+    assert_equal(*result_pair.("/...//.././././/."))
+    assert_equal(*result_pair.("./../..///.../..//"))
+    assert_equal(*result_pair.("///././././/.//..."))
+    assert_equal(*result_pair.("./../..///.../..//././"))
+    assert_equal(*result_pair.("///././././/.//....///"))
+    assert_equal(*result_pair.("http://www.example.com"))
+    assert_equal(*result_pair.("foor for thought"))
+    assert_equal(*result_pair.("2gb63b@%TY25GHawefb3/g3qb"))
+  end
 end

--- a/test/benches/add_trailing_separator_benchmark.rb
+++ b/test/benches/add_trailing_separator_benchmark.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'minitest/benchmark'
+
+class FasterPathBenchmark < Minitest::Benchmark
+  def bench_rust_add_trailing_separator
+    assert_performance_constant do |n|
+      100_000.times do
+        FasterPath.add_trailing_separator('/hello/world')
+        FasterPath.add_trailing_separator('/hello/world/')
+      end
+    end
+  end
+
+  def bench_ruby_add_trailing_separator
+    assert_performance_constant do |n|
+      100_000.times do
+        Pathname.allocate.send(:add_trailing_separator, '/hello/world')
+        Pathname.allocate.send(:add_trailing_separator, '/hello/world/')
+      end
+    end
+  end
+end
+

--- a/test/monkeypatches/faster_path_test.rb
+++ b/test/monkeypatches/faster_path_test.rb
@@ -26,4 +26,8 @@ class MonkeyPatchesTest < Minitest::Test
   def test_it_redefines_relative?
     assert @path.method(:relative?).source[/FasterPath/] 
   end
+
+  def test_it_redefines_add_trailing_separator
+    assert @path.method(:add_trailing_separator).source[/FasterPath/]
+  end
 end if ENV['TEST_MONKEYPATCHES'].to_s['true']

--- a/test/refinements/add_trailing_separator_test.rb
+++ b/test/refinements/add_trailing_separator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'faster_path/optional/refinements'
+
+class RefinedPathname
+  using FasterPath::RefinePathname
+  def add_trailing_separator(pth)
+    Pathname.allocate.send(:add_trailing_separator, pth)
+  end
+end
+
+class AddTrailingSeparatorTest < Minitest::Test
+  def test_refines_pathname_add_trailing_separator
+    assert RefinedPathname.allocate.send(:add_trailing_separator, 'hello')
+  end
+
+  def test_refines_pathname_add_trailing_separator_in_dosish_context
+    if File.dirname('A:') == 'A:.'
+      assert RefinedPathname.allocate.send(:add_trailing_separator, 'A:')
+    end
+  end
+end


### PR DESCRIPTION
* Implement Pathname.add_trailing_separator in Rust
* Hook Rust function into FasterPath as
  FasterPath.add_trailing_separator
* Add FasterPath.add_trailing_separator monkeypatch and
  refinement
* Add tests and benchmarks for FasterPath.add_trailing_separator
  against Pathname.add_trailing_separator

https://github.com/danielpclark/faster_path/issues/43