### PR TITLE
Add FasterPath.has_trailing_separator?

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Current methods implemented:
 | `FasterPath.blank?` | | |
 | `FasterPath.directory?` | `Pathname#directory?` | 20% |
 | `FasterPath.add_trailing_separator` | `Pathname#add_trailing_separator` | 63.8% |
+| `FasterPath.has_trailing_separator?` | `Pathname#has_trailing_separator` | 61.2% |
 
 You may choose to use the methods directly, or scope change to rewrite behavior on the
 standard library with the included refinements, or even call a method to monkeypatch 

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -39,6 +39,10 @@ module FasterPath
     Rust.add_trailing_separator(pth)
   end
 
+  def self.has_trailing_separator?(pth)
+    Rust.has_trailing_separator(pth)
+  end
+
   # EXAMPLE
   #def self.one_and_two
   #  Rust.one_and_two.to_a
@@ -71,6 +75,7 @@ module FasterPath
     attach_function :basename_for_chop, [ :string ], :string # decoupling behavior
     attach_function :dirname_for_chop, [ :string ], :string # decoupling behavior
     attach_function :add_trailing_separator, [ :string ], :string
+    attach_function :has_trailing_separator, [ :string ], :bool
 
     # EXAMPLE
     #attach_function :one_and_two, [], FromRustArray.by_value

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -24,10 +24,15 @@ module FasterPath
         FasterPath.relative?(@path)
       end
 
-     def add_trailing_separator(pth)
+      def add_trailing_separator(pth)
         FasterPath.add_trailing_separator(pth)
-     end
-     private :add_trailing_separator
+      end
+      private :add_trailing_separator
+
+      def has_trailing_separator?(pth)
+        FasterPath.has_trailing_separator?(pth)
+      end
+      private :has_trailing_separator?
     end
   end
 end

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -30,6 +30,10 @@ module FasterPath
         FasterPath.add_trailing_separator(pth)
       end
       private :add_trailing_separator
+
+      def has_trailing_separator?(pth)
+        FasterPath.has_trailing_separator?(pth)
+      end
     end
   end
 end

--- a/src/has_trailing_separator.rs
+++ b/src/has_trailing_separator.rs
@@ -1,0 +1,25 @@
+use std::path::{Path, MAIN_SEPARATOR};
+use libc::c_char;
+use std::ffi::CStr;
+use std::str;
+
+#[no_mangle]
+pub extern "C" fn has_trailing_separator(string: *const c_char) -> bool {
+    let c_str = unsafe {
+        assert!(!string.is_null());
+        CStr::from_ptr(string)
+    };
+
+    let r_str = str::from_utf8(c_str.to_bytes()).unwrap_or("");
+    let path = Path::new(r_str);
+    let last_component = path.iter().last();
+    if last_component.is_none() {
+        false
+    } else {
+        let mut parts: Vec<&str> = r_str.rsplit_terminator(MAIN_SEPARATOR).collect();
+        parts.retain(|x| !x.is_empty());
+        let last_part = parts.first().unwrap_or(&"").chars().last().unwrap_or(MAIN_SEPARATOR);
+        let last_char = r_str.chars().last().unwrap();
+        (last_part != last_char) && (last_char == MAIN_SEPARATOR)
+    }
+}

--- a/src/has_trailing_separator.rs
+++ b/src/has_trailing_separator.rs
@@ -6,7 +6,9 @@ use std::str;
 #[no_mangle]
 pub extern "C" fn has_trailing_separator(string: *const c_char) -> bool {
     let c_str = unsafe {
-        assert!(!string.is_null());
+        if string.is_null() {
+            return false
+        }
         CStr::from_ptr(string)
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dirname;
 pub mod basename_for_chop;
 pub mod dirname_for_chop;
 pub mod add_trailing_separator;
+pub mod has_trailing_separator;
 
 // EXAMPLE
 //

--- a/test/benches/has_trailing_separator_benchmark.rb
+++ b/test/benches/has_trailing_separator_benchmark.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+require 'minitest/benchmark'
+
+class FasterPathBenchmark < Minitest::Benchmark
+  def bench_rust_has_trailing_separator
+    assert_performance_constant do |n|
+      100_000.times do
+        FasterPath.has_trailing_separator? '////a//aaa/a//a/aaa////'
+        FasterPath.has_trailing_separator? 'hello/'
+      end
+    end
+  end
+
+  def bench_ruby_has_trailing_separator
+    assert_performance_constant do |n|
+      100_000.times do
+        Pathname.allocate.send :has_trailing_separator?, '////a//aaa/a//a/aaa////'
+        Pathname.allocate.send :has_trailing_separator?, 'hello/'
+      end
+    end
+  end
+end

--- a/test/has_trailing_separator_test.rb
+++ b/test/has_trailing_separator_test.rb
@@ -51,4 +51,17 @@ class HasTrailingSeparatorTest < Minitest::Test
     assert_equal(*result_pair.("foor for thought"))
     assert_equal(*result_pair.("2gb63b@%TY25GHawefb3/g3qb"))
   end
+
+  def test_has_trailing_separator_with_nil
+    assert_equal test_for_error { FasterPath.has_trailing_separator?(nil) }, 'OK'
+  end
+
+  private
+
+  def test_for_error
+    yield if block_given?
+    'OK'
+  rescue
+    $!
+  end
 end

--- a/test/has_trailing_separator_test.rb
+++ b/test/has_trailing_separator_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class HasTrailingSeparatorTest < Minitest::Test
+  def test_has_trailing_separator_against_pathname_implementation
+    result_pair = -> (str) {
+      [
+        Pathname.allocate.send(:has_trailing_separator?, str),
+        FasterPath.has_trailing_separator?(str)
+      ]
+    }
+
+    assert_equal(*result_pair.(''))
+    assert_equal(*result_pair.('/'))
+    assert_equal(*result_pair.('//'))
+    assert_equal(*result_pair.('///'))
+    assert_equal(*result_pair.('hello'))
+    assert_equal(*result_pair.('hello/'))
+    assert_equal(*result_pair.('/hello/'))
+    assert_equal(*result_pair.('/hello//'))
+    assert_equal(*result_pair.('.'))
+    assert_equal(*result_pair.('./'))
+    assert_equal(*result_pair.('.//'))
+    assert_equal(*result_pair.("aa/a//a"))
+    assert_equal(*result_pair.("/aaa/a//a"))
+    assert_equal(*result_pair.("/aaa/a//a/a"))
+    assert_equal(*result_pair.("/aaa/a//a/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa"))
+    assert_equal(*result_pair.("/aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("a//aaa/a//a/aaa////"))
+    assert_equal(*result_pair.("a/a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("////a//aaa/a//a/aaa/a"))
+    assert_equal(*result_pair.("////a//aaa/a//a/aaa////"))
+    assert_equal(*result_pair.("."))
+    assert_equal(*result_pair.(".././"))
+    assert_equal(*result_pair.(".///.."))
+    assert_equal(*result_pair.("/././/"))
+    assert_equal(*result_pair.("//../././"))
+    assert_equal(*result_pair.(".///.../.."))
+    assert_equal(*result_pair.("/././/.//."))
+    assert_equal(*result_pair.("/...//../././"))
+    assert_equal(*result_pair.("/..///.../..//"))
+    assert_equal(*result_pair.("/./././/.//..."))
+    assert_equal(*result_pair.("/...//.././././/."))
+    assert_equal(*result_pair.("./../..///.../..//"))
+    assert_equal(*result_pair.("///././././/.//..."))
+    assert_equal(*result_pair.("./../..///.../..//././"))
+    assert_equal(*result_pair.("///././././/.//....///"))
+    assert_equal(*result_pair.("http://www.example.com"))
+    assert_equal(*result_pair.("foor for thought"))
+    assert_equal(*result_pair.("2gb63b@%TY25GHawefb3/g3qb"))
+  end
+end

--- a/test/has_trailing_separator_test.rb
+++ b/test/has_trailing_separator_test.rb
@@ -53,15 +53,6 @@ class HasTrailingSeparatorTest < Minitest::Test
   end
 
   def test_has_trailing_separator_with_nil
-    assert_equal test_for_error { FasterPath.has_trailing_separator?(nil) }, 'OK'
-  end
-
-  private
-
-  def test_for_error
-    yield if block_given?
-    'OK'
-  rescue
-    $!
+    refute FasterPath.has_trailing_separator?(nil)
   end
 end

--- a/test/monkeypatches/faster_path_test.rb
+++ b/test/monkeypatches/faster_path_test.rb
@@ -33,7 +33,7 @@ class MonkeyPatchesTest < Minitest::Test
     end
 
     def test_it_redefines_has_trailing_separator
-      assert @path.method(:has_trailing_separator).source[/FasterPath/]
+      assert @path.method(:has_trailing_separator?).source[/FasterPath/]
     end
   else
     def test_it_redefines_absolute?
@@ -57,7 +57,7 @@ class MonkeyPatchesTest < Minitest::Test
     end
 
     def test_it_redefines_has_trailing_separator
-      refute @path.method(:has_trailing_separator).source[/FasterPath/]
+      refute @path.method(:has_trailing_separator?).source[/FasterPath/]
     end
   end
 end

--- a/test/monkeypatches/faster_path_test.rb
+++ b/test/monkeypatches/faster_path_test.rb
@@ -30,4 +30,8 @@ class MonkeyPatchesTest < Minitest::Test
   def test_it_redefines_add_trailing_separator
     assert @path.method(:add_trailing_separator).source[/FasterPath/]
   end
+
+  def test_it_redefines_has_trailing_separator
+    assert @path.method(:has_trailing_separator?).source[/FasterPath/]
+  end
 end if ENV['TEST_MONKEYPATCHES'].to_s['true']

--- a/test/refinements/has_trailing_separator_test.rb
+++ b/test/refinements/has_trailing_separator_test.rb
@@ -1,0 +1,12 @@
+class RefinedPathname
+  using FasterPath::RefinePathname
+  def has_trailing_separator?(path)
+    Pathname.new(path).has_trailing_separator?
+  end
+end
+
+class HasTrailingSeparatorRefinementTest < Minitest::Test
+  def test_refines_pathname_has_trailing_separator?
+    assert RefinedPathname.new.has_trailing_separator? "a/"
+  end
+end


### PR DESCRIPTION
* Implement Pathname#has_trailing_separator? in Rust
* Hook Rust function into FasterPath as
  FasterPath.has_trailing_separator?
* Add FasterPath.has_trailing_separator? monkeypatch and
  refinement
* Add tests and benchmarks for FasterPath.has_trailing_separator?
  against Pathname#has_trailing_separator?

https://github.com/danielpclark/faster_path/issues/49