### PR TITLE
Fixes a couple of extname edge cases

### DIFF
--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -1,14 +1,14 @@
 module FasterPath
   def self.sledgehammer_everything!
     ::File.class_eval do
-      def basename(pth)
+      def self.basename(pth)
         FasterPath.basename(pth)
-      end
+      end if ENV['WITH_REGRESSION']
 
-      def extname(pth)
+      def self.extname(pth)
         FasterPath.extname(pth)
       end
-    end 
+    end
 
     ::Pathname.class_eval do
       def absolute?

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -1,15 +1,15 @@
 module FasterPath
   module RefineFile
     refine File do
-      def basename(pth)
+      def self.basename(pth)
         FasterPath.basename(pth)
-      end
+      end if ENV['WITH_REGRESSION']
 
-      def extname(pth)
+      def self.extname(pth)
         FasterPath.extname(pth)
       end
     end
-  end 
+  end
 
   module RefinePathname
     refine Pathname do

--- a/src/extname.rs
+++ b/src/extname.rs
@@ -1,53 +1,34 @@
 use std::path::MAIN_SEPARATOR;
 use libc::c_char;
 use std::ffi::{CStr, CString};
-use std::str;
 
 #[no_mangle]
 pub extern "C" fn extname(string: *const c_char) -> *const c_char {
-    let c_str = unsafe {
-        if string.is_null() {
-          return string
-        }
-        CStr::from_ptr(string)
-    };
-
-    let r_str = str::from_utf8(c_str.to_bytes()).unwrap_or("");
-
-    let mut chars_iter = r_str.char_indices().rev();
+    if string.is_null() {
+        return string
+    }
+    let r_str = unsafe { CStr::from_ptr(string) }.to_str().unwrap_or("")
+      .trim_right_matches(MAIN_SEPARATOR);
 
     let mut reversed_ext: Vec<u8> = Vec::new();
     let mut dot_index = 0;
     let mut separator_index = 0;
-    loop {
-        let char = chars_iter.next();
-        if char.is_some() {
-            if char.unwrap().1 != MAIN_SEPARATOR {
-                if char.unwrap().1 == '.' {
-                    dot_index = char.unwrap().0;
-                    reversed_ext.push(char.unwrap().1 as u8);
-                    break;
-                } else {
-                    reversed_ext.push(char.unwrap().1 as u8);
-                }
-            } else {
-                separator_index = char.unwrap().0;
+    for (pos, char) in r_str.char_indices().rev() {
+        if char != MAIN_SEPARATOR {
+            reversed_ext.push(char as u8);
+            if char == '.' {
+                dot_index = pos;
                 break;
             }
         } else {
+            separator_index = pos;
             break;
         }
     }
 
-    if separator_index >= dot_index {
+    if separator_index >= dot_index || reversed_ext.len() == 1 {
         return CString::new("").unwrap().into_raw();
     }
-
-    if reversed_ext.len() == 1 {
-        return CString::new("").unwrap().into_raw();
-    }
-
     reversed_ext.reverse();
-    let output = CString::new(reversed_ext).unwrap();
-    output.into_raw()
+    CString::new(reversed_ext).unwrap().into_raw()
 }

--- a/test/benches/extname_benchmark.rb
+++ b/test/benches/extname_benchmark.rb
@@ -2,12 +2,19 @@ require "test_helper"
 require "minitest/benchmark"
 
 class FasterPathBenchmark < Minitest::Benchmark
+  CASES = %w(
+    verylongfilename_verylongfilename_verylongfilename_verylongfilename.rb
+    /very/long/path/name/very/long/path/name/very/long/path/name/file.rb
+    /ext/mail.rb
+    lots/of/trailing/slashes.rb/////////////////////
+    .hiddenfile
+    very_long_extension_verylongextensionverylongextensionverylongextensionverylongextension.rb
+  ) + ['']
+
   def bench_rust_extname
     assert_performance_constant do |n|
       100000.times do
-        FasterPath.extname('verylongfilename_verylongfilename.rb')
-        FasterPath.extname('/very/long/path/name/very/long/path/name/very/long/path/name/file.rb')
-        FasterPath.extname('/ext/mail.rb')
+        CASES.each { |path| FasterPath.extname(path) }
       end
     end
   end
@@ -15,9 +22,7 @@ class FasterPathBenchmark < Minitest::Benchmark
   def bench_ruby_extname
     assert_performance_constant do |n|
       100000.times do
-        File.extname('verylongfilename_verylongfilename.rb')
-        File.extname('/very/long/path/name/very/long/path/name/very/long/path/name/file.rb')
-        File.extname('/ext/main.rb')
+        CASES.each { |path| File.extname(path) }
       end
     end
   end

--- a/test/extname_test.rb
+++ b/test/extname_test.rb
@@ -25,6 +25,8 @@ class ExtnameTest < Minitest::Test
     assert_equal "", FasterPath.extname("....")
     assert_equal "", FasterPath.extname(".foo.")
     assert_equal "", FasterPath.extname("foo.")
+    # TODO: fix
+    # assert_equal "", FasterPath.extname("..foo")
   end
 
   def test_substitutability_of_rust_and_ruby_impls
@@ -50,5 +52,7 @@ class ExtnameTest < Minitest::Test
     assert_equal( *result_pair.("....")                      )
     assert_equal( *result_pair.(".foo.")                     )
     assert_equal( *result_pair.("foo.")                      )
+    assert_equal( *result_pair.("foo.rb/")                   )
+    assert_equal( *result_pair.("foo.rb//")                  )
   end
 end


### PR DESCRIPTION
Also adds a commmented out test for a failing case NOT resolved by this PR.

```
$ rake pbench
Pinch-bench (Pbench) by Daniel P. Clark
--------------------------------------------------------------------------------
64-bit ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
64-bit rustc 1.9.0 (e4e8b6668 2016-05-18)
--------------------------------------------------------------------------------
Performance change for allocate, instead of new, is 80.6%
Performance change for absolute? is 92.8%
Performance change for add_trailing_separator is 55.4%
Performance change for basename is 1.3%
Performance change for chop_basename is 22.3%
Performance change for directory? is 32.8%
Performance change for extname is 49.6%
Performance change for has_trailing_separator? is 45.8%
Performance change for blank? (verses strip.empty?) is -89.1%
Performance change for relative? is 92.0%
Started with run options --seed 17737
```