### PR TITLE
basename: Improve performance and style

### DIFF
--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -1,8 +1,8 @@
 module FasterPath
   def self.sledgehammer_everything!
     ::File.class_eval do
-      def self.basename(pth)
-        FasterPath.basename(pth)
+      def self.basename(pth, ext = '')
+        FasterPath.basename(pth, ext)
       end if ENV['WITH_REGRESSION']
 
       def self.extname(pth)

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -1,8 +1,8 @@
 module FasterPath
   module RefineFile
     refine File do
-      def self.basename(pth)
-        FasterPath.basename(pth)
+      def self.basename(pth, ext = '')
+        FasterPath.basename(pth, ext)
       end if ENV['WITH_REGRESSION']
 
       def self.extname(pth)

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,86 +1,26 @@
 use std::path::MAIN_SEPARATOR;
 use libc::c_char;
-use std::ffi::{CStr,CString};
-use std::str;
-
-#[allow(dead_code)]
-fn rubyish_basename(string: &str, globish_string: &str) -> String {
-  let result = if globish_string == ".*" {
-    let base = string.rsplit_terminator(MAIN_SEPARATOR).nth(0).unwrap_or("");
-    let index = base.rfind(".");
-    let (first, _) = base.split_at(index.unwrap());
-    first
-  } else {
-    if &string[string.len()-globish_string.len()..] == globish_string {
-      &string[0..string.len()-globish_string.len()]
-    } else {
-      string
-    }.rsplit_terminator(MAIN_SEPARATOR).nth(0).unwrap_or("")
-  };
-  result.to_string()
-}
-
-#[test]
-fn it_chomps_strings_correctly(){
-  assert_eq!(rubyish_basename("","")                           , "");
-  assert_eq!(rubyish_basename("ruby","")                       , "ruby");
-  assert_eq!(rubyish_basename("ruby.rb",".rb")                 , "ruby");
-  assert_eq!(rubyish_basename("ruby.rb",".*")                  , "ruby");
-  assert_eq!(rubyish_basename(".ruby/ruby.rb",".rb")           , "ruby");
-  assert_eq!(rubyish_basename(".ruby/ruby.rb.swp",".rb")       , "ruby.rb.swp");
-  assert_eq!(rubyish_basename(".ruby/ruby.rb.swp",".swp")      , "ruby.rb");
-  assert_eq!(rubyish_basename(".ruby/ruby.rb.swp",".*")        , "ruby.rb");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp","")           , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".*")        , "asdf.rb"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", "*")         , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".")         , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".*")        , "asdf.rb"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".rb")       , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".swp")      , "asdf.rb"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".sw")       , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".sw*")      , "asdf.rb.swp"); 
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".rb.s*")    , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".s*")       , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".s**")      , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".**")       , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".*")        , "asdf.rb");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".*.*")      , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".rb.swp")   , "asdf");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".rb.s*p")   , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".r*.s*p")   , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".r*.sw*p")  , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", ".r*b.sw*p") , "asdf.rb.swp");
-  assert_eq!(rubyish_basename("asdf/asdf.rb.swp", "rb.swp")    , "asdf.");
-}
+use std::ffi::{CStr, CString};
 
 #[no_mangle]
-pub extern fn basename(str_pth: *const c_char, comp_ext: *const c_char) -> *const c_char {
-  let c_str1 = unsafe {
-    if str_pth.is_null(){
-      return str_pth;
-    } 
-    CStr::from_ptr(str_pth)
-  };
-  let c_str2 = unsafe {
-    if comp_ext.is_null() {
-      return str_pth;
-    }
-    CStr::from_ptr(comp_ext)
-  };
-  let string         = str::from_utf8(c_str1.to_bytes()).unwrap();
-  let globish_string = str::from_utf8(c_str2.to_bytes()).unwrap();
+pub extern "C" fn basename(c_pth: *const c_char, c_ext: *const c_char) -> *const c_char {
+  // TODO: rb_raise on type or encoding errors
+  // TODO: support objects that respond to `to_path`
+  if c_pth.is_null() || c_ext.is_null() {
+    return c_pth;
+  }
+  let pth = unsafe { CStr::from_ptr(c_pth) }.to_str().unwrap();
+  let ext = unsafe { CStr::from_ptr(c_ext) }.to_str().unwrap();
 
-  let result = if globish_string == ".*" {
-    let base = string.rsplit_terminator(MAIN_SEPARATOR).nth(0).unwrap_or("");
-    let index = base.rfind(".");
-    let (first, _) = base.split_at(index.unwrap());
-    first
-  } else {
-    if &string[string.len()-globish_string.len()..] == globish_string {
-      &string[0..string.len()-globish_string.len()]
-    } else {
-      string
-    }.rsplit_terminator(MAIN_SEPARATOR).nth(0).unwrap_or("")
+  let mut name = pth.trim_right_matches(MAIN_SEPARATOR).rsplit(MAIN_SEPARATOR).next().unwrap_or("");
+
+  if ext == ".*" {
+    if let Some(dot_i) = name.rfind('.') {
+      name = &name[0..dot_i];
+    }
+  } else if name.ends_with(ext) {
+    name = &name[..name.len() - ext.len()];
   };
-  CString::new(result).unwrap().into_raw()
+
+  CString::new(name).unwrap().into_raw()
 }

--- a/test/basename_test.rb
+++ b/test/basename_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BasenameTest < Minitest::Test
   def test_nil_inputs
-    assert_nil FasterPath.basename(nil,nil) 
+    assert_nil FasterPath.basename(nil,nil)
     assert_equal FasterPath.basename('',nil), ""
     assert_nil FasterPath.basename(nil,'')
     assert_equal FasterPath.basename('asdf',nil), "asdf"
@@ -21,18 +21,19 @@ class BasenameTest < Minitest::Test
     assert_equal FasterPath.basename('ruby.rb', ''),      'ruby.rb'
     assert_equal FasterPath.basename('ruby.rbx', '.rb*'), 'ruby.rbx'
     assert_equal FasterPath.basename('ruby.rbx'), 'ruby.rbx'
-    
+
     # Try some extensions w/o a '.'
     assert_equal FasterPath.basename('ruby.rbx', 'rbx'), 'ruby.'
     assert_equal FasterPath.basename('ruby.rbx', 'x'),   'ruby.rb'
     assert_equal FasterPath.basename('ruby.rbx', '*'),   'ruby.rbx'
-    
+
     # A couple of regressions:
     assert_equal FasterPath.basename('', ''),           ''
     assert_equal FasterPath.basename('/'),              '/'
     assert_equal FasterPath.basename('//'),             '/'
     assert_equal FasterPath.basename('//dir///base//'), 'base'
-  end 
+    assert_equal FasterPath.basename('.x', '.x'), '.x'
+  end
 
   def test_it_does_the_same_as_file_basename
     assert_equal File.basename('/home/gumby/work/ruby.rb'),        'ruby.rb'
@@ -45,12 +46,12 @@ class BasenameTest < Minitest::Test
     assert_equal File.basename('ruby.rb', ''),      'ruby.rb'
     assert_equal File.basename('ruby.rbx', '.rb*'), 'ruby.rbx'
     assert_equal File.basename('ruby.rbx'), 'ruby.rbx'
-    
+
     # Try some extensions w/o a '.'
     assert_equal File.basename('ruby.rbx', 'rbx'), 'ruby.'
     assert_equal File.basename('ruby.rbx', 'x'),   'ruby.rb'
     assert_equal File.basename('ruby.rbx', '*'),   'ruby.rbx'
-    
+
     # A couple of regressions:
     assert_equal File.basename('', ''),           ''
     assert_equal File.basename('/'),              '/'


### PR DESCRIPTION
More idiomatic, slightly faster, extracted from #66 

```
$  WITH_REGRESSION=1 rake pbench
Pinch-bench (Pbench) by Daniel P. Clark
--------------------------------------------------------------------------------
64-bit ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
64-bit rustc 1.9.0 (e4e8b6668 2016-05-18)
--------------------------------------------------------------------------------
Performance change for allocate, instead of new, is 80.1%
Performance change for absolute? is 92.8%
Performance change for add_trailing_separator is 55.3%
Performance change for basename is 6.3%
Performance change for chop_basename is 26.6%
Performance change for directory? is 32.6%
Performance change for extname is 51.1%
Performance change for has_trailing_separator? is 52.1%
Performance change for blank? (verses strip.empty?) is -93.9%
Performance change for relative? is 92.2%
Started with run options --seed 51653
```