### PR TITLE
Fix extname edge case

### DIFF
--- a/src/extname.rs
+++ b/src/extname.rs
@@ -3,32 +3,20 @@ use libc::c_char;
 use std::ffi::{CStr, CString};
 
 #[no_mangle]
-pub extern "C" fn extname(string: *const c_char) -> *const c_char {
-    if string.is_null() {
-        return string
-    }
-    let r_str = unsafe { CStr::from_ptr(string) }.to_str().unwrap_or("")
-      .trim_right_matches(MAIN_SEPARATOR);
+pub extern "C" fn extname(c_pth: *const c_char) -> *const c_char {
+  if c_pth.is_null() {
+    return c_pth
+  }
 
-    let mut reversed_ext: Vec<u8> = Vec::new();
-    let mut dot_index = 0;
-    let mut separator_index = 0;
-    for (pos, char) in r_str.char_indices().rev() {
-        if char != MAIN_SEPARATOR {
-            reversed_ext.push(char as u8);
-            if char == '.' {
-                dot_index = pos;
-                break;
-            }
-        } else {
-            separator_index = pos;
-            break;
-        }
-    }
+  let name = unsafe { CStr::from_ptr(c_pth) }.to_str().unwrap()
+    .trim_right_matches(MAIN_SEPARATOR)
+    .rsplit(MAIN_SEPARATOR).next().unwrap_or("");
 
-    if separator_index >= dot_index || reversed_ext.len() == 1 {
-        return CString::new("").unwrap().into_raw();
+  if let Some(dot_i) = name.rfind('.') {
+    if dot_i > 0 && dot_i < name.len() - 1 && name[..dot_i].chars().rev().next().unwrap() != '.' {
+      return CString::new(&name[dot_i..]).unwrap().into_raw()
     }
-    reversed_ext.reverse();
-    CString::new(reversed_ext).unwrap().into_raw()
+  }
+
+  CString::new("").unwrap().into_raw()
 }

--- a/test/extname_test.rb
+++ b/test/extname_test.rb
@@ -25,8 +25,7 @@ class ExtnameTest < Minitest::Test
     assert_equal "", FasterPath.extname("....")
     assert_equal "", FasterPath.extname(".foo.")
     assert_equal "", FasterPath.extname("foo.")
-    # TODO: fix
-    # assert_equal "", FasterPath.extname("..foo")
+    assert_equal "", FasterPath.extname("..foo")
   end
 
   def test_substitutability_of_rust_and_ruby_impls


### PR DESCRIPTION
Fixes the last non-encoding/`#to_path`/TypeError related extname edge case.
However, this is a bit slower than the current impl :(

```
$ WITH_REGRESSION=1 rake pbench
Pinch-bench (Pbench) by Daniel P. Clark
--------------------------------------------------------------------------------
64-bit ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
64-bit rustc 1.9.0 (e4e8b6668 2016-05-18)
--------------------------------------------------------------------------------
Performance change for allocate, instead of new, is 80.9%
Performance change for absolute? is 92.9%
Performance change for add_trailing_separator is 55.6%
Performance change for basename is 6.2%
Performance change for chop_basename is 30.1%
Performance change for directory? is 41.0%
Performance change for extname is 35.5%
Performance change for has_trailing_separator? is 56.1%
Performance change for blank? (verses strip.empty?) is -88.7%
Performance change for relative? is 92.5%
Started with run options --seed 24064
```