### PR TITLE
Reduce development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ Methods will be written as exclusively in Rust as possible.  Even just writing a
 Rust method like `!absolute?` _(not absolute)_ drops 39% of the performance already gained in Rust.
 Whenever feasible implement it in Rust.
 
-After checking out the repo, make sure you have Rust installed.  Then run `bundle && rake build_lib` .
-Then, run `rake test` to run the tests, and `rake bench` for benchmarks.
+After checking out the repo, make sure you have Rust installed, then run `bundle`.
+Run `rake test` to run the tests, and `rake bench` for benchmarks.
 
 Learn and share performance tips on the [wiki](https://github.com/danielpclark/faster_path/wiki)!
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,13 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'fileutils'
 
-desc "Building extension..."
+desc "Build Rust extension"
 task :build_src do
   puts "Building extension..."
   system("cargo build --release")
 end
 
-desc "Cleaning up build..."
+desc "Clean up Rust build"
 task :clean_src do
   puts "Cleaning up build..."
   # Remove all but library file
@@ -22,7 +22,7 @@ task :clean_src do
   )
 end
 
-desc "Compiling Rust extension..."
+desc "Build + clean up Rust extension"
 task build_lib: [:build_src, :clean_src] do
   puts "Completed build!"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :clean_src do
 end
 
 desc "Compiling Rust extension..."
-task :build_lib => [:build_src, :clean_src] do
+task build_lib: [:build_src, :clean_src] do
   puts "Completed build!"
 end
 
@@ -43,4 +43,4 @@ Rake::TestTask.new(:pbench) do |t|
   t.pattern = 'test/pbench/pbench_suite.rb'
 end
 
-task :default => :test
+task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -27,18 +27,18 @@ task build_lib: [:build_src, :clean_src] do
   puts "Completed build!"
 end
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new(test: :build_lib) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-Rake::TestTask.new(:bench) do |t|
+Rake::TestTask.new(bench: :build_lib) do |t|
   t.libs = %w(lib test)
   t.pattern = 'test/**/*_benchmark.rb'
 end
 
-Rake::TestTask.new(:pbench) do |t|
+Rake::TestTask.new(pbench: :build_lib) do |t|
   t.libs = %w(lib test test/pbench)
   t.pattern = 'test/pbench/pbench_suite.rb'
 end


### PR DESCRIPTION
Reduces the amount of steps required for someone to start developing, by explicitly requiring `build_lib` to be run before any of the test tasks.

Also did some cleanup while I was in there.