### PR TITLE
Faster basename, dirname, extname

### DIFF
--- a/benches/path_parsing.rs
+++ b/benches/path_parsing.rs
@@ -1,0 +1,72 @@
+#![feature(test)]
+extern crate libc;
+extern crate test;
+use std::path::MAIN_SEPARATOR;
+
+static SEP: u8 = MAIN_SEPARATOR as u8;
+
+pub fn extract_last_path_segment_str(path: &str) -> &str {
+  path.trim_right_matches(MAIN_SEPARATOR).rsplit(MAIN_SEPARATOR).next().unwrap_or("")
+}
+
+pub fn extract_last_path_segment_bytes(mut path: &str) -> &str {
+  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
+  // avoid the overhead of full UTF-8 processing.
+  path = match path.bytes().rposition(|b| b != SEP) {
+    Some(pos) => &path[..pos + 1],
+    _ => &path[..0]
+  };
+  if let Some(pos) = path.bytes().rposition(|b| b == SEP) {
+    path = &path[pos + 1..];
+  }
+  path
+}
+
+pub fn extract_last_path_segment_pointer(path: &str) -> &str {
+  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
+  // avoid the overhead of full UTF-8 processing.
+  let ptr = path.as_ptr();
+  let mut i = path.len() as isize - 1;
+  while i >= 0 {
+    let c = unsafe { *ptr.offset(i) };
+    if c != SEP { break; };
+    i -= 1;
+  }
+  let end = (i + 1) as usize;
+  while i >= 0 {
+    let c = unsafe { *ptr.offset(i) };
+    if c == SEP {
+      return &path[(i + 1) as usize..end];
+    };
+    i -= 1;
+  }
+  &path[..end]
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use test::Bencher;
+  use test::black_box;
+
+  static PATH_FOR_BENCH: &'static str = "/hellooooooooo/woλλλλrλd/";
+
+  #[bench]
+  fn bench_extract_last_path_segment_bytes(b: &mut Bencher) {
+    let path = black_box(PATH_FOR_BENCH);
+    b.iter(|| extract_last_path_segment_bytes(path));
+  }
+
+  #[bench]
+  fn bench_extract_last_path_segment_str(b: &mut Bencher) {
+    let path = black_box(PATH_FOR_BENCH);
+    b.iter(|| extract_last_path_segment_str(path));
+  }
+
+  #[bench]
+  fn bench_extract_last_path_segment_pointer(b: &mut Bencher) {
+    let path = black_box(PATH_FOR_BENCH);
+    b.iter(|| extract_last_path_segment_pointer(path));
+  }
+}

--- a/benches/rust_ruby.rs
+++ b/benches/rust_ruby.rs
@@ -14,7 +14,7 @@ fn rust_to_ruby_c_char_convenient(b: &mut Bencher){
   let s: String = "hello".to_string();
 
   // (185ns)
-  b.iter(|| { 
+  b.iter(|| {
     let s = s.clone(); //To imitate .into()
     let s_slice: &str = &s[..];
     CString::new(s_slice).unwrap().into_raw()
@@ -28,7 +28,7 @@ fn rust_to_ruby_c_char(b: &mut Bencher){
   let s = s.as_str();
 
   // USE THIS METHOD!!! (153ns)
-  b.iter(|| { 
+  b.iter(|| {
     CString::new(s).unwrap().into_raw()
   })
 }
@@ -39,7 +39,7 @@ fn ruby_to_rust_string_convenient(b: &mut Bencher){
   let s: *const c_char = CString::new("hello").unwrap().into_raw();
 
   // (46ns)
-  b.iter(|| { 
+  b.iter(|| {
     let c_str = unsafe {
       assert!(!s.is_null());
       CStr::from_ptr(s)
@@ -51,11 +51,11 @@ fn ruby_to_rust_string_convenient(b: &mut Bencher){
 
 // SANCTIONED USAGE
 #[bench]
-fn ruby_to_rust_from_c_char(b: &mut Bencher){
+fn ruby_to_rust_from_c_char_from_utf8(b: &mut Bencher){
   let s: *const c_char = CString::new("hello").unwrap().into_raw();
 
   // USE THIS METHOD!!! (19ns)
-  b.iter(|| { 
+  b.iter(|| {
     let c_str = unsafe {
       if s.is_null() {
         return "";
@@ -64,4 +64,16 @@ fn ruby_to_rust_from_c_char(b: &mut Bencher){
     };
     str::from_utf8(c_str.to_bytes()).unwrap_or("")
   })
+}
+
+
+#[bench]
+fn ruby_to_rust_from_c_char_to_str(b: &mut Bencher) {
+  let s: *const c_char = CString::new("hello").unwrap().into_raw();
+  b.iter(|| {
+    if s.is_null() {
+      return "";
+    }
+    unsafe { CStr::from_ptr(s) }.to_str().unwrap_or("")
+  });
 }

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,6 +1,6 @@
-use std::path::MAIN_SEPARATOR;
 use libc::c_char;
 use std::ffi::{CStr, CString};
+use path_parsing::extract_last_path_segment;
 
 #[no_mangle]
 pub extern "C" fn basename(c_pth: *const c_char, c_ext: *const c_char) -> *const c_char {
@@ -12,7 +12,7 @@ pub extern "C" fn basename(c_pth: *const c_char, c_ext: *const c_char) -> *const
   let pth = unsafe { CStr::from_ptr(c_pth) }.to_str().unwrap();
   let ext = unsafe { CStr::from_ptr(c_ext) }.to_str().unwrap();
 
-  let mut name = pth.trim_right_matches(MAIN_SEPARATOR).rsplit(MAIN_SEPARATOR).next().unwrap_or("");
+  let mut name = extract_last_path_segment(pth);
 
   if ext == ".*" {
     if let Some(dot_i) = name.rfind('.') {

--- a/src/dirname.rs
+++ b/src/dirname.rs
@@ -1,70 +1,32 @@
 use std::path::MAIN_SEPARATOR;
 use libc::c_char;
-use std::ffi::{CStr,CString};
-use std::str;
+use std::ffi::{CStr, CString};
+use path_parsing::{last_sep_i, last_non_sep_i, last_non_sep_i_before};
 
 #[no_mangle]
-pub extern "C" fn dirname(string: *const c_char) -> *const c_char {
-    let c_str = unsafe {
-        if string.is_null() {
-            return string
-        }
-
-        CStr::from_ptr(string)
-    };
-
-    let r_str = str::from_utf8(c_str.to_bytes()).unwrap();
-
-    if r_str.is_empty() {
-
-        return CString::new(".").unwrap().into_raw();
-    }
-
-    let last_none_slash = r_str.char_indices()
-        .rev()
-        .find(|&(_, char)| char != MAIN_SEPARATOR);
-
-    if !last_none_slash.is_some() {
-        return CString::new("/").unwrap().into_raw();
-    }
-
-    let most_right_slash = r_str[0..last_none_slash.unwrap().0]
-        .char_indices()
-        .rev()
-        .find(|&(_, char)| char == MAIN_SEPARATOR);
-
-    if most_right_slash.is_some() {
-
-        if most_right_slash.unwrap().0 == 0 {
-
-            return CString::new("/").unwrap().into_raw();
-        }
-
-        let path = &r_str[0..most_right_slash.unwrap().0];
-
-        if path == &MAIN_SEPARATOR.to_string() {
-
-            return CString::new("/").unwrap().into_raw();
-        }
-
-        if !path.ends_with(&MAIN_SEPARATOR.to_string()) {
-
-            return CString::new(path).unwrap().into_raw();
-        }
-
-        let path_last_none_slash = path.char_indices()
-            .rev()
-            .find(|&(_, char)| char != MAIN_SEPARATOR);
-
-        if !path_last_none_slash.is_some() {
-
-            return CString::new("/").unwrap().into_raw();
-        }
-
-
-        return CString::new(&path[0..(path_last_none_slash.unwrap().0 + 1)]).unwrap().into_raw();
-    } else {
-
-        return CString::new(".").unwrap().into_raw();
-    }
+pub extern "C" fn dirname(path: *const c_char) -> *const c_char {
+  if path.is_null() {
+    return path
+  }
+  let r_str = unsafe { CStr::from_ptr(path) }.to_str().unwrap();
+  if r_str.is_empty() {
+    return CString::new(".").unwrap().into_raw();
+  }
+  let non_sep_i = last_non_sep_i(r_str);
+  if non_sep_i == -1 {
+    return CString::new(MAIN_SEPARATOR.to_string()).unwrap().into_raw();
+  }
+  let sep_i = last_sep_i(r_str, non_sep_i);
+  if sep_i == -1 {
+    return CString::new(".").unwrap().into_raw();
+  }
+  if sep_i == 0 {
+    return CString::new(MAIN_SEPARATOR.to_string()).unwrap().into_raw();
+  }
+  let non_sep_i2 = last_non_sep_i_before(r_str, sep_i);
+  if non_sep_i2 != -1 {
+    return CString::new(&r_str[..(non_sep_i2 + 1) as usize]).unwrap().into_raw();
+  } else {
+    return CString::new(MAIN_SEPARATOR.to_string()).unwrap().into_raw();
+  }
 }

--- a/src/extname.rs
+++ b/src/extname.rs
@@ -1,6 +1,6 @@
-use std::path::MAIN_SEPARATOR;
 use libc::c_char;
 use std::ffi::{CStr, CString};
+use path_parsing::extract_last_path_segment;
 
 #[no_mangle]
 pub extern "C" fn extname(c_pth: *const c_char) -> *const c_char {
@@ -8,9 +8,7 @@ pub extern "C" fn extname(c_pth: *const c_char) -> *const c_char {
     return c_pth
   }
 
-  let name = unsafe { CStr::from_ptr(c_pth) }.to_str().unwrap()
-    .trim_right_matches(MAIN_SEPARATOR)
-    .rsplit(MAIN_SEPARATOR).next().unwrap_or("");
+  let name = extract_last_path_segment(unsafe { CStr::from_ptr(c_pth) }.to_str().unwrap());
 
   if let Some(dot_i) = name.rfind('.') {
     if dot_i > 0 && dot_i < name.len() - 1 && name[..dot_i].chars().rev().next().unwrap() != '.' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod add_trailing_separator;
 pub mod has_trailing_separator;
 pub mod extname;
 pub mod rust_arch_bits;
+mod path_parsing;
 
 // EXAMPLE
 //

--- a/src/path_parsing.rs
+++ b/src/path_parsing.rs
@@ -1,0 +1,55 @@
+use std::path::MAIN_SEPARATOR;
+
+static SEP: u8 = MAIN_SEPARATOR as u8;
+
+pub fn extract_last_path_segment(path: &str) -> &str {
+  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
+  // avoid the overhead of full UTF-8 processing.
+  // See src/benches/path_parsing.rs for benchmarks of different approaches.
+  let ptr = path.as_ptr();
+  let mut i = path.len() as isize - 1;
+  while i >= 0 {
+    let c = unsafe { *ptr.offset(i) };
+    if c != SEP { break; };
+    i -= 1;
+  }
+  let end = (i + 1) as usize;
+  while i >= 0 {
+    let c = unsafe { *ptr.offset(i) };
+    if c == SEP {
+      return &path[(i + 1) as usize..end];
+    };
+    i -= 1;
+  }
+  &path[..end]
+}
+
+
+// Returns the byte offset of the last byte preceding a MAIN_SEPARATOR.
+pub fn last_non_sep_i(path: &str) -> isize {
+  last_non_sep_i_before(path, path.len() as isize - 1)
+}
+
+// Returns the byte offset of the last byte preceding a MAIN_SEPARATOR before the given end offset.
+pub fn last_non_sep_i_before(path: &str, end: isize) -> isize {
+  let ptr = path.as_ptr();
+  let mut i = end;
+  while i >= 0 {
+    if unsafe { *ptr.offset(i) } != SEP { break; };
+    i -= 1;
+  }
+  i
+}
+
+// Returns the byte offset of the last MAIN_SEPARATOR before the given end offset.
+pub fn last_sep_i(path: &str, end: isize) -> isize {
+  let ptr = path.as_ptr();
+  let mut i = end - 1;
+  while i >= 0 {
+    if unsafe { *ptr.offset(i) } == SEP {
+      return i;
+    };
+    i -= 1;
+  }
+  -1
+}


### PR DESCRIPTION
Benches several ways of working with paths at low level.
Changes the methods to use the fastest approach.

```
$ rake pbench
Building extension...
   Compiling libc v0.2.11
   Compiling faster_path v0.0.1 (file:///home/glebm/repos/glebm/faster_path)
Cleaning up build...
Completed build!
Pinch-bench (Pbench) by Daniel P. Clark
--------------------------------------------------------------------------------
64-bit ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
64-bit rustc 1.11.0-nightly (ad7fe6521 2016-06-23)
--------------------------------------------------------------------------------
Performance change for allocate, instead of new, is 80.6%
Performance change for absolute? is 92.4%
Performance change for add_trailing_separator is 54.4%
Performance change for basename is 4.7%
Performance change for chop_basename is 27.8%
Performance change for directory? is 33.8%
Performance change for dirname is -11.8%
Performance change for extname is 36.1%
Performance change for has_trailing_separator? is 49.5%
Performance change for blank? (verses strip.empty?) is -80.7%
Performance change for relative? is 91.9%
Started with run options --seed 5107
```

cargo bench:
```
$ cargo bench
     Running target/release/faster_path-107c566d7e5973d7

running 1 test
test rust_arch_bits::it_is_32_or_64 ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured

     Running target/release/path_parsing-9132e73b45e51362

running 3 tests
test tests::bench_extract_last_path_segment_bytes   ... bench:           8 ns/iter (+/- 0)
test tests::bench_extract_last_path_segment_pointer ... bench:           5 ns/iter (+/- 1)
test tests::bench_extract_last_path_segment_str     ... bench:          26 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured

     Running target/release/rust_ruby-737dd477eaa16f6c

running 5 tests
test ruby_to_rust_from_c_char_from_utf8 ... bench:          11 ns/iter (+/- 0)
test ruby_to_rust_from_c_char_to_str    ... bench:          10 ns/iter (+/- 0)
test ruby_to_rust_string_convenient     ... bench:          21 ns/iter (+/- 2)
test rust_to_ruby_c_char                ... bench:          80 ns/iter (+/- 9)
test rust_to_ruby_c_char_convenient     ... bench:          86 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured
```