### PR TITLE
Fail rake task if shell failed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'fileutils'
 desc "Build Rust extension"
 task :build_src do
   puts "Building extension..."
-  system("cargo build --release")
+  sh "cargo build --release"
 end
 
 desc "Clean up Rust build"
@@ -31,7 +31,7 @@ desc "Code Quality Check"
 task :lint do
   puts
   puts "Quality check starting..."
-  system("rubocop")
+  sh "rubocop"
   puts
 end
 


### PR DESCRIPTION
before 

```
➜  faster_path git:(master) ✗ rake build_src
Building extension...
➜  faster_path git:(master) ✗ echo $?
0
```

after

```
➜  faster_path git:(fail-rake-task-if-shell-failed) ✗ rake build_src
Building extension...
cargo build --release
rake aborted!
Command failed with status (127): [cargo build --release...]
faster_path/Rakefile:8:in `block in <top (required)>'
Tasks: TOP => build_src
(See full trace by running task with --trace)
➜  faster_path git:(fail-rake-task-if-shell-failed) ✗ echo $?
1
```