### PR TITLE
Children method & re-org methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Current methods implemented:
 |---|---|:---:|
 | `FasterPath.absolute?` | `Pathname#absolute?` | 88.5% |
 | `FasterPath.add_trailing_separator` | `Pathname#add_trailing_separator` | 31.1% |
+| `FasterPath.children` | `Pathname#children` | 13.6% |
 | `FasterPath.chop_basename` | `Pathname#chop_basename` | 55.8% |
 | `FasterPath.directory?` | `Pathname#directory?` | 12.7% |
 | `FasterPath.entries` | `Pathname#entries` | 7.7% |

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -14,14 +14,18 @@ module FasterPath
     new(library['Init_faster_pathname'], [], Fiddle::TYPE_VOIDP).
     call
 
-  FasterPathname.class_eval do
+  FasterPathname::Public.class_eval do
+    private :absolute?
     private :add_trailing_separator
     private :basename
     private :chop_basename
+    private :directory?
     private :dirname
     private :entries
     private :extname
+    private :has_trailing_separator?
     private :plus
+    private :relative?
   end
 
   def self.rust_arch_bits
@@ -33,11 +37,11 @@ module FasterPath
   end
 
   def self.absolute?(pth)
-    FasterPathname.allocate.send(:absolute?, pth)
+    FasterPathname::Public.allocate.send(:absolute?, pth)
   end
 
   def self.add_trailing_separator(pth)
-    FasterPathname.allocate.send(:add_trailing_separator, pth)
+    FasterPathname::Public.allocate.send(:add_trailing_separator, pth)
   end
 
   def self.blank?(str)
@@ -45,40 +49,40 @@ module FasterPath
   end
 
   def self.basename(pth, ext="")
-    FasterPathname.allocate.send(:basename, pth, ext)
+    FasterPathname::Public.allocate.send(:basename, pth, ext)
   end
 
   def self.chop_basename(pth)
-    result = FasterPathname.allocate.send(:chop_basename, pth)
+    result = FasterPathname::Public.allocate.send(:chop_basename, pth)
     result unless result.empty?
   end
 
   def self.directory?(pth)
-    FasterPathname.allocate.send(:directory?, pth)
+    FasterPathname::Public.allocate.send(:directory?, pth)
   end
 
   def self.dirname(pth)
-    FasterPathname.allocate.send(:dirname, pth)
+    FasterPathname::Public.allocate.send(:dirname, pth)
   end
 
   def self.entries(pth)
-    FasterPathname.allocate.send(:entries, pth)
+    FasterPathname::Public.allocate.send(:entries, pth)
   end
 
   def self.extname(pth)
-    FasterPathname.allocate.send(:extname, pth)
+    FasterPathname::Public.allocate.send(:extname, pth)
   end
 
   def self.has_trailing_separator?(pth)
-    FasterPathname.allocate.send(:has_trailing_separator?, pth)
+    FasterPathname::Public.allocate.send(:has_trailing_separator?, pth)
   end
 
   def self.plus(pth, pth2)
-    FasterPathname.allocate.send(:plus, pth, pth2)
+    FasterPathname::Public.allocate.send(:plus, pth, pth2)
   end
 
   def self.relative?(pth)
-    FasterPathname.allocate.send(:relative?, pth)
+    FasterPathname::Public.allocate.send(:relative?, pth)
   end
 
   module Rust

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -18,6 +18,7 @@ module FasterPath
     private :absolute?
     private :add_trailing_separator
     private :basename
+    private :children
     private :chop_basename
     private :directory?
     private :dirname
@@ -26,6 +27,26 @@ module FasterPath
     private :has_trailing_separator?
     private :plus
     private :relative?
+  end
+
+  FasterPathname.class_eval do
+    def initialize(arg)
+      unless arg.is_a? String
+        arg = arg.to_s
+      end
+      raise(ArgumentError, "null byte found") if arg.include?("\0")
+      @path = arg
+    end
+
+    # BAD; exposes private methods
+    # Need to reprivatize specific methods
+    def method_missing(method_name, *a, &b)
+      Public.send(method_name, @path, *a, &b)
+    end
+
+    def respond_to?(method_name, include_private = false)
+      Public.send(:respond_to?, method_name) || super
+    end
   end
 
   def self.rust_arch_bits
@@ -50,6 +71,10 @@ module FasterPath
 
   def self.basename(pth, ext="")
     FasterPathname::Public.allocate.send(:basename, pth, ext)
+  end
+
+  def self.children(pth, with_directory=true)
+    FasterPathname::Public.allocate.send(:children, pth, with_directory)
   end
 
   def self.chop_basename(pth)

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -26,23 +26,11 @@ module FasterPath
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def self._ruby_library_pathname!
       ::Pathname.class_eval do
         def absolute?
           FasterPath.absolute?(@path)
-        end
-
-        def directory?
-          FasterPath.directory?(@path)
-        end
-
-        def chop_basename(pth)
-          FasterPath.chop_basename(pth)
-        end
-        private :chop_basename
-
-        def relative?
-          FasterPath.relative?(@path)
         end
 
         def add_trailing_separator(pth)
@@ -50,19 +38,36 @@ module FasterPath
         end
         private :add_trailing_separator
 
-        def has_trailing_separator?(pth)
-          FasterPath.has_trailing_separator?(pth)
+        def children(with_dir=true)
+          FasterPath.children(@path, with_dir)
         end
-        private :has_trailing_separator?
+
+        def chop_basename(pth)
+          FasterPath.chop_basename(pth)
+        end
+        private :chop_basename
+
+        def directory?
+          FasterPath.directory?(@path)
+        end
 
         def entries
           FasterPath.entries(@path)
         end
 
+        def has_trailing_separator?(pth)
+          FasterPath.has_trailing_separator?(pth)
+        end
+        private :has_trailing_separator?
+
         def plus(pth, pth2)
           FasterPath.plus(pth, pth2)
         end
         private :plus
+
+        def relative?
+          FasterPath.relative?(@path)
+        end
       end
     end
   end

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -29,8 +29,13 @@ module FasterPath
         FasterPath.absolute?(@path)
       end
 
-      def directory?
-        FasterPath.directory?(@path)
+      def add_trailing_separator(pth)
+        FasterPath.add_trailing_separator(pth)
+      end
+      private :add_trailing_separator
+
+      def children(with_dir=true)
+        FasterPath.children(@path, with_dir)
       end
 
       def chop_basename(pth)
@@ -38,27 +43,26 @@ module FasterPath
       end
       private :chop_basename
 
-      def relative?
-        FasterPath.relative?(@path)
-      end
-
-      def add_trailing_separator(pth)
-        FasterPath.add_trailing_separator(pth)
-      end
-      private :add_trailing_separator
-
-      def has_trailing_separator?(pth)
-        FasterPath.has_trailing_separator?(pth)
+      def directory?
+        FasterPath.directory?(@path)
       end
 
       def entries
         FasterPath.entries(@path)
       end
 
+      def has_trailing_separator?(pth)
+        FasterPath.has_trailing_separator?(pth)
+      end
+
       def plus(pth, pth2)
         FasterPath.plus(pth, pth2)
       end
       private :plus
+
+      def relative?
+        FasterPath.relative?(@path)
+      end
     end
   end
 end

--- a/lib/faster_path/version.rb
+++ b/lib/faster_path/version.rb
@@ -1,3 +1,3 @@
 module FasterPath
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate ruru;
 
 class!(FasterPathname);
 
+mod pathname;
 mod basename;
 mod chop_basename;
 mod dirname;
@@ -18,126 +19,148 @@ pub mod rust_arch_bits;
 mod path_parsing;
 
 use ruru::{Class, Object, RString, Boolean, Array};
-use std::path::{MAIN_SEPARATOR,Path};
-use std::fs;
 
+// r_ methods are on the core class and may evaluate instance variables or self
+// pub_ methods must take all values as parameters
 methods!(
   FasterPathname,
   _itself,
 
-  fn r_add_trailing_separator(pth: RString) -> RString {
-    let p = pth.ok().unwrap();
-    let x = format!("{}{}", p.to_str(), "a");
-    match x.rsplit_terminator(MAIN_SEPARATOR).next() {
-      Some("a") => p,
-      _ => RString::new(format!("{}{}", p.to_str(), MAIN_SEPARATOR).as_str())
-    }
+  // TOPATH = :to_path
+
+  // SAME_PATHS = if File::FNM_SYSCASE.nonzero?
+  //   # Avoid #zero? here because #casecmp can return nil.
+  //   proc {|a, b| a.casecmp(b) == 0}
+  // else
+  //   proc {|a, b| a == b}
+  // end
+
+  // if File::ALT_SEPARATOR
+  //   SEPARATOR_LIST = "#{Regexp.quote File::ALT_SEPARATOR}#{Regexp.quote File::SEPARATOR}"
+  //   SEPARATOR_PAT = /[#{SEPARATOR_LIST}]/
+  // else
+  //   SEPARATOR_LIST = "#{Regexp.quote File::SEPARATOR}"
+  //   SEPARATOR_PAT = /#{Regexp.quote File::SEPARATOR}/
+  // end
+
+  fn pub_add_trailing_separator(pth: RString) -> RString {
+    pathname::pn_add_trailing_separator(pth)
   }
 
-  fn r_is_absolute(pth: RString) -> Boolean {
-    Boolean::new(match pth.ok().unwrap_or(RString::new("")).to_str().chars().next() {
-      Some(c) => c == MAIN_SEPARATOR,
-      None => false
-    })
+  fn pub_is_absolute(pth: RString) -> Boolean {
+    pathname::pn_is_absolute(pth)
   }
 
-  fn r_basename(pth: RString, ext: RString) -> RString {
-    RString::new(
-      &basename::basename(
-        pth.ok().unwrap_or(RString::new("")).to_str(),
-        ext.ok().unwrap_or(RString::new("")).to_str()
-      )[..]
-    )
+  // fn r_ascend(){}
+
+  fn pub_basename(pth: RString, ext: RString) -> RString {
+    pathname::pn_basename(pth, ext)
   }
 
-  fn r_chop_basename(pth: RString) -> Array {
-    let mut arr = Array::with_capacity(2);
-    let results = chop_basename::chop_basename(pth.ok().unwrap_or(RString::new("")).to_str());
-    match results {
-      Some((dirname, basename)) => {
-        arr.push(RString::new(&dirname[..]));
-        arr.push(RString::new(&basename[..]));
-        arr
-      },
-      None => arr
-    }
+  // fn r_children(with_dir: Boolean){}
+
+  fn pub_chop_basename(pth: RString) -> Array {
+    pathname::pn_chop_basename(pth)
   }
 
-  fn r_is_directory(pth: RString) -> Boolean {
-    Boolean::new(
-      Path::new(
-        pth.ok().unwrap_or(RString::new("")).to_str()
-      ).is_dir()
-    )
+  // fn r_cleanpath(){ pub_cleanpath(r_to_path()) }
+  // fn pub_cleanpath(pth: RString){}
+
+  // fn r_cleanpath_aggressive(pth: RString){}
+
+  // fn r_cleanpath_conservative(pth: RString){}
+
+  // fn r_del_trailing_separator(pth: RString){}
+
+  // fn r_descend(){}
+
+  fn pub_is_directory(pth: RString) -> Boolean {
+    pathname::pn_is_directory(pth)
   }
 
-  fn r_dirname(pth: RString) -> RString {
-    RString::new(
-      &dirname::dirname(
-        pth.ok().unwrap_or(RString::new("")).to_str()
-      )[..]
-    )
+  fn pub_dirname(pth: RString) -> RString {
+    pathname::pn_dirname(pth)
   }
 
-  fn r_entries(pth: RString) -> Array {
-    let files = fs::read_dir(pth.ok().unwrap_or(RString::new("")).to_str()).unwrap();
-    let mut arr = Array::new();
+  // fn r_each_child(){}
+  // fn pub_each_child(){}
 
-    arr.push(RString::new("."));
-    arr.push(RString::new(".."));
+  // fn pub_each_filename(pth: RString) -> NilClass {
+  //   pathname::pn_each_filename(pth)
+  // }
 
-    for file in files {
-      let file_name_str = file.unwrap().file_name().into_string().unwrap();
-      arr.push(RString::new(&file_name_str[..]));
-    }
-
-    arr
+  fn pub_entries(pth: RString) -> Array {
+    pathname::pn_entries(pth)
   }
 
-  fn r_extname(pth: RString) -> RString {
-    RString::new(
-      &extname::extname(pth.ok().unwrap_or(RString::new("")).to_str())[..]
-    )
+  fn pub_extname(pth: RString) -> RString {
+    pathname::pn_extname(pth)
   }
 
-  fn r_has_trailing_separator(pth: RString) -> Boolean {
-    let v = pth.ok().unwrap_or(RString::new(""));
-    match chop_basename::chop_basename(v.to_str()) {
-      Some((a,b)) => {
-        Boolean::new(a.len() + b.len() < v.to_str().len())
-      },
-      _ => Boolean::new(false)
-    }
+  // fn r_find(ignore_error: Boolean){}
+  // fn pub_find(pth: RString ,ignore_error: Boolean){}
+  
+  fn pub_has_trailing_separator(pth: RString) -> Boolean {
+    pathname::pn_has_trailing_separator(pth)
   }
 
-  fn r_plus(pth1: RString, pth2: RString) -> RString {
-    RString::new(&plus::plus_paths(pth1.ok().unwrap().to_str(), pth2.ok().unwrap().to_str())[..])
+  // fn r_join(args: Array){}
+
+  // fn pub_mkpath(pth: RString) -> NilClass {
+  //   pathname::pn_mkpath(pth)
+  // }
+
+  // fn r_is_mountpoint(){ pub_is_mountpount(r_to_path()) }
+  // fn pub_is_mountpoint(pth: RString){}
+
+  // fn r_parent(){ pub_parent(r_to_path()) }
+  // fn pub_parent(pth: RString){}
+
+  // also need impl +
+  fn pub_plus(pth1: RString, pth2: RString) -> RString {
+    pathname::pn_plus(pth1, pth2)
   }
 
-  fn r_is_relative(pth: RString) -> Boolean {
-    Boolean::new(
-      match pth.ok().unwrap_or(RString::new(&MAIN_SEPARATOR.to_string()[..])).to_str().chars().next() {
-        Some(c) => c != MAIN_SEPARATOR,
-        None => true
-      }
-    )
+  // fn r_prepend_prefix(prefix: RString, relpath: RString){}
+
+  fn pub_is_relative(pth: RString) -> Boolean {
+    pathname::pn_is_relative(pth)
   }
+
+  // fn r_root(){ pub_root(r_to_path()) }
+  // fn pub_root(pth: RString){}
+
+  // fn r_split_names(pth: RString){}
+
+  // fn r_relative_path_from(){}
+  // fn pub_relative_path_from(){}
+
+  // fn pub_rmtree(pth: RString) -> NilClass {
+  //   pathname::pn_rmtree(pth)
+  // }
 );
 
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_faster_pathname(){
   Class::new("FasterPathname", None).define(|itself| {
-    itself.def("absolute?", r_is_absolute);
-    itself.def("add_trailing_separator", r_add_trailing_separator);
-    itself.def("basename", r_basename);
-    itself.def("chop_basename", r_chop_basename);
-    itself.def("directory?", r_is_directory);
-    itself.def("dirname", r_dirname);
-    itself.def("entries", r_entries);
-    itself.def("extname", r_extname);
-    itself.def("has_trailing_separator?", r_has_trailing_separator);
-    itself.def("plus", r_plus);
-    itself.def("relative?", r_is_relative);
+    itself.define_nested_class("Public", None);
+  });
+
+  // Public methods
+  // * methods for refinements, monkeypatching
+  // * methods that need all values as parameters
+  Class::from_existing("FasterPathname").get_nested_class("Public").define(|itself| {
+    itself.def("absolute?", pub_is_absolute);
+    itself.def("add_trailing_separator", pub_add_trailing_separator);
+    itself.def("basename", pub_basename);
+    itself.def("chop_basename", pub_chop_basename);
+    itself.def("directory?", pub_is_directory);
+    itself.def("dirname", pub_dirname);
+    itself.def("entries", pub_entries);
+    itself.def("extname", pub_extname);
+    itself.def("has_trailing_separator?", pub_has_trailing_separator);
+    itself.def("plus", pub_plus);
+    itself.def("relative?", pub_is_relative);
   });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,9 @@ methods!(
     pathname::pn_basename(pth, ext)
   }
 
-  // fn r_children(with_dir: Boolean){}
+  fn pub_children(pth: RString, with_dir: Boolean) -> Array {
+    pathname::pn_children(pth, with_dir)
+  }
 
   fn pub_chop_basename(pth: RString) -> Array {
     pathname::pn_chop_basename(pth)
@@ -154,6 +156,7 @@ pub extern "C" fn Init_faster_pathname(){
     itself.def("absolute?", pub_is_absolute);
     itself.def("add_trailing_separator", pub_add_trailing_separator);
     itself.def("basename", pub_basename);
+    itself.def("children", pub_children);
     itself.def("chop_basename", pub_chop_basename);
     itself.def("directory?", pub_is_directory);
     itself.def("dirname", pub_dirname);

--- a/src/pathname.rs
+++ b/src/pathname.rs
@@ -9,23 +9,6 @@ use ruru::{RString, Boolean, Array};
 use std::path::{MAIN_SEPARATOR,Path};
 use std::fs;
 
-// TOPATH = :to_path
-
-// SAME_PATHS = if File::FNM_SYSCASE.nonzero?
-//   # Avoid #zero? here because #casecmp can return nil.
-//   proc {|a, b| a.casecmp(b) == 0}
-// else
-//   proc {|a, b| a == b}
-// end
-
-// if File::ALT_SEPARATOR
-//   SEPARATOR_LIST = "#{Regexp.quote File::ALT_SEPARATOR}#{Regexp.quote File::SEPARATOR}"
-//   SEPARATOR_PAT = /[#{SEPARATOR_LIST}]/
-// else
-//   SEPARATOR_LIST = "#{Regexp.quote File::SEPARATOR}"
-//   SEPARATOR_PAT = /#{Regexp.quote File::SEPARATOR}/
-// end
-
 pub fn pn_add_trailing_separator(pth: Result<ruru::RString, ruru::result::Error>) -> RString {
   let p = pth.ok().unwrap();
   let x = format!("{}{}", p.to_str(), "a");
@@ -53,7 +36,32 @@ pub fn pn_basename(pth: Result<ruru::RString, ruru::result::Error>, ext: Result<
   )
 }
 
-// pub fn pn_children(pth: Result<ruru::RString, ruru::result::Error>, with_dir: Boolean){}
+pub fn pn_children(pth: Result<ruru::RString, ruru::result::Error>, with_dir: Result<ruru::Boolean, ruru::result::Error>) -> Array {
+  let rstring = pth.ok().unwrap_or(RString::new("."));
+  let val = rstring.to_str();
+  let mut with_directory = with_dir.ok().unwrap_or(Boolean::new(true)).to_bool();
+  if val == "." {
+    with_directory = false;
+  }
+  let mut arr = Array::new();
+
+  if let Ok(entries) = fs::read_dir(val) {
+    for entry in entries {
+      if with_directory {
+        match entry {
+          Ok(v) => { arr.push(RString::new(v.path().to_str().unwrap())); },
+          _ => {}
+        };
+      } else {
+        match entry {
+          Ok(v) => { arr.push(RString::new(v.file_name().to_str().unwrap())); },
+          _ => {}
+        };
+      }
+    }
+  }
+  arr
+}
 
 pub fn pn_chop_basename(pth: Result<ruru::RString, ruru::result::Error>) -> Array {
   let mut arr = Array::with_capacity(2);

--- a/src/pathname.rs
+++ b/src/pathname.rs
@@ -1,0 +1,171 @@
+use basename;
+use chop_basename;
+use dirname;
+use extname;
+use plus;
+
+use ruru;
+use ruru::{RString, Boolean, Array};
+use std::path::{MAIN_SEPARATOR,Path};
+use std::fs;
+
+// TOPATH = :to_path
+
+// SAME_PATHS = if File::FNM_SYSCASE.nonzero?
+//   # Avoid #zero? here because #casecmp can return nil.
+//   proc {|a, b| a.casecmp(b) == 0}
+// else
+//   proc {|a, b| a == b}
+// end
+
+// if File::ALT_SEPARATOR
+//   SEPARATOR_LIST = "#{Regexp.quote File::ALT_SEPARATOR}#{Regexp.quote File::SEPARATOR}"
+//   SEPARATOR_PAT = /[#{SEPARATOR_LIST}]/
+// else
+//   SEPARATOR_LIST = "#{Regexp.quote File::SEPARATOR}"
+//   SEPARATOR_PAT = /#{Regexp.quote File::SEPARATOR}/
+// end
+
+pub fn pn_add_trailing_separator(pth: Result<ruru::RString, ruru::result::Error>) -> RString {
+  let p = pth.ok().unwrap();
+  let x = format!("{}{}", p.to_str(), "a");
+  match x.rsplit_terminator(MAIN_SEPARATOR).next() {
+    Some("a") => p,
+    _ => RString::new(format!("{}{}", p.to_str(), MAIN_SEPARATOR).as_str())
+  }
+}
+
+pub fn pn_is_absolute(pth: Result<ruru::RString, ruru::result::Error>) -> Boolean {
+  Boolean::new(match pth.ok().unwrap_or(RString::new("")).to_str().chars().next() {
+    Some(c) => c == MAIN_SEPARATOR,
+    None => false
+  })
+}
+
+// pub fn pn_ascend(){}
+
+pub fn pn_basename(pth: Result<ruru::RString, ruru::result::Error>, ext: Result<ruru::RString, ruru::result::Error>) -> RString {
+  RString::new(
+    &basename::basename(
+      pth.ok().unwrap_or(RString::new("")).to_str(),
+      ext.ok().unwrap_or(RString::new("")).to_str()
+    )[..]
+  )
+}
+
+// pub fn pn_children(pth: Result<ruru::RString, ruru::result::Error>, with_dir: Boolean){}
+
+pub fn pn_chop_basename(pth: Result<ruru::RString, ruru::result::Error>) -> Array {
+  let mut arr = Array::with_capacity(2);
+  let results = chop_basename::chop_basename(pth.ok().unwrap_or(RString::new("")).to_str());
+  match results {
+    Some((dirname, basename)) => {
+      arr.push(RString::new(&dirname[..]));
+      arr.push(RString::new(&basename[..]));
+      arr
+    },
+    None => arr
+  }
+}
+
+// pub fn pn_cleanpath(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_cleanpath_aggressive(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_cleanpath_conservative(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_del_trailing_separator(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_descend(){}
+
+pub fn pn_is_directory(pth: Result<ruru::RString, ruru::result::Error>) -> Boolean {
+  Boolean::new(
+    Path::new(
+      pth.ok().unwrap_or(RString::new("")).to_str()
+    ).is_dir()
+  )
+}
+
+pub fn pn_dirname(pth: Result<ruru::RString, ruru::result::Error>) -> RString {
+  RString::new(
+    &dirname::dirname(
+      pth.ok().unwrap_or(RString::new("")).to_str()
+    )[..]
+  )
+}
+
+// pub fn pn_each_child(){}
+
+// pub fn pn_each_filename(pth: Result<ruru::RString, ruru::result::Error>) -> NilClass {
+//   NilClass::new()
+// }
+
+pub fn pn_entries(pth: Result<ruru::RString, ruru::result::Error>) -> Array {
+  let files = fs::read_dir(pth.ok().unwrap_or(RString::new("")).to_str()).unwrap();
+  let mut arr = Array::new();
+
+  arr.push(RString::new("."));
+  arr.push(RString::new(".."));
+
+  for file in files {
+    let file_name_str = file.unwrap().file_name().into_string().unwrap();
+    arr.push(RString::new(&file_name_str[..]));
+  }
+
+  arr
+}
+
+pub fn pn_extname(pth: Result<ruru::RString, ruru::result::Error>) -> RString {
+  RString::new(
+    &extname::extname(pth.ok().unwrap_or(RString::new("")).to_str())[..]
+  )
+}
+
+// pub fn pn_find(pth: Result<ruru::RString, ruru::result::Error> ,ignore_error: Boolean){}
+
+pub fn pn_has_trailing_separator(pth: Result<ruru::RString, ruru::result::Error>) -> Boolean {
+  let v = pth.ok().unwrap_or(RString::new(""));
+  match chop_basename::chop_basename(v.to_str()) {
+    Some((a,b)) => {
+      Boolean::new(a.len() + b.len() < v.to_str().len())
+    },
+    _ => Boolean::new(false)
+  }
+}
+
+// pub fn pn_join(args: Array){}
+
+// pub fn pn_mkpath(pth: Result<ruru::RString, ruru::result::Error>) -> NilClass {
+//   NilClass::new()
+// }
+
+// pub fn pn_is_mountpoint(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_parent(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// also need impl +
+pub fn pn_plus(pth1: Result<ruru::RString, ruru::result::Error>, pth2: Result<ruru::RString, ruru::result::Error>) -> RString {
+  RString::new(&plus::plus_paths(pth1.ok().unwrap().to_str(), pth2.ok().unwrap().to_str())[..])
+}
+
+// pub fn pn_prepend_prefix(prefix: Result<ruru::RString, ruru::result::Error>, relpath: Result<ruru::RString, ruru::result::Error>){}
+
+pub fn pn_is_relative(pth: Result<ruru::RString, ruru::result::Error>) -> Boolean {
+  Boolean::new(
+    match pth.ok().unwrap_or(RString::new(&MAIN_SEPARATOR.to_string()[..])).to_str().chars().next() {
+      Some(c) => c != MAIN_SEPARATOR,
+      None => true
+    }
+  )
+}
+
+// pub fn pn_root(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_split_names(pth: Result<ruru::RString, ruru::result::Error>){}
+
+// pub fn pn_relative_path_from(){}
+
+// pub fn pn_rmtree(pth: Result<ruru::RString, ruru::result::Error>) -> NilClass {
+//   NilClass::new()
+// }
+

--- a/test/benches/children_benchmark.rb
+++ b/test/benches/children_benchmark.rb
@@ -1,0 +1,34 @@
+require "benchmark_helper"
+
+class ChildrenBenchmark < BenchmarkHelper
+  def self.bench_range
+    [20, 40, 60, 80, 100]
+  end
+
+  def setup
+    @file ||= __FILE__
+    @one = "."
+    @two = "../"
+  end
+
+  def teardown
+    super
+    graph_benchmarks
+  end
+
+  def bench_rust_children
+    benchmark :rust do
+      FasterPath.children(@one)
+      FasterPath.children(@two, false)
+    end
+  end
+
+  def bench_ruby_children
+    one = Pathname.new(@one)
+    two = Pathname.new(@two)
+    benchmark :ruby do
+      one.children
+      two.children(false)
+    end
+  end
+end

--- a/test/children_test.rb
+++ b/test/children_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ChildrenTest < Minitest::Test
+  def test_it_returns_similar_results_to_pathname_children?
+    [".", "/", "../"].each do |pth|
+      assert_equal Pathname.new(pth).children.map(&:to_s),
+                   FasterPath.children(pth)
+    end
+  end
+end

--- a/test/faster_pathname.rb
+++ b/test/faster_pathname.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class FasterPathnameTest < Minitest::Test
+  def test_it_safely_takes_nil
+    assert FasterPath.new(nil)
+  end
+
+  def test_it_creates_itself
+    assert FasterPathname.new("/hello")
+    assert_kind_of FasterPathname.new("/hello"), FasterPathname
+  end
+
+  def test_it_catches_null_byte
+    assert_raises ArgumentError do
+      FasterPathname.new("\0")
+    end
+  end
+end

--- a/test/pbench/pbench_suite.rb
+++ b/test/pbench/pbench_suite.rb
@@ -71,6 +71,18 @@ PBENCHES[:basename] = {
     end
   end
 }
+PBENCHES[:children] = {
+  new: lambda do |x|
+    (x/5).times do
+      FasterPath.children(".")
+    end
+  end,
+  old: lambda do |x|
+    (x/5).times do
+      Pathname.new(".").children
+    end
+  end
+}
 PBENCHES[:chop_basename] = {
   new: lambda do |x|
     x.times do
@@ -119,13 +131,13 @@ PBENCHES[:dirname] = {
 }
 PBENCHES[:entries] = {
   new: lambda do |x|
-    x.times do
+    (x/5).times do
       FasterPath.entries("./")
       FasterPath.entries("./src")
     end
   end,
   old: lambda do |x|
-    x.times do
+    (x/5).times do
       Pathname.new("./").entries
       Pathname.new("./src").entries
     end


### PR DESCRIPTION
Comments for next methods to be implemented added.

Methods moved out of ruru's `methods!` macro for future instance variable referencing private methods.

Directory parsing methods do less iterations during pinch benchmark suite.

Prep work for FasterPathname to be drop in replacement for Pathname.  Note: The C methods will be mapped to directly in the future through Rust calls through ruby-sys.

Fixes #114 