### PR TITLE
Compat methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -883,7 +883,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: true
 
-Naming/BinaryOperatorParameter:
+Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -439,7 +439,7 @@ Layout/AccessModifierIndentation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
   Enabled: true
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
@@ -483,7 +483,7 @@ Style/AsciiComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
@@ -539,7 +539,7 @@ Style/CharacterLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
   Enabled: true
 
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Description: 'Use CamelCase for classes and modules.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#camelcase-classes'
   Enabled: true
@@ -585,7 +585,7 @@ Layout/CommentIndentation:
   Description: 'Indentation of comments.'
   Enabled: false
 
-Style/ConstantName:
+Naming/ConstantName:
   Description: 'Constants should use SCREAMING_SNAKE_CASE.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
   Enabled: false
@@ -679,7 +679,7 @@ Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
 
-Style/FileName:
+Naming/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: true
@@ -795,7 +795,7 @@ Style/MethodDefParentheses:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: false
 
-Style/MethodName:
+Naming/MethodName:
   Description: 'Use the configured style when naming methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
   Enabled: true
@@ -883,7 +883,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: true
 
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: true
@@ -925,7 +925,7 @@ Style/PerlBackrefs:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
   Enabled: true
 
-Style/PredicateName:
+Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   Enabled: false
@@ -1195,7 +1195,7 @@ Style/VariableInterpolation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#curlies-interpolate'
   Enabled: true
 
-Style/VariableName:
+Namingg/VariableName:
   Description: 'Use the configured style when naming variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
   Enabled: true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,25 @@
+# Style ***
+
+control_style = "Legacy"
+chain_indent = "Visual"
+fn_brace_style = "PreferSameLine"
+fn_args_layout = "Visual"
+fn_args_density = "CompressedIfEmpty"
+where_layout = "HorizontalVertical"
+where_pred_indent = "Visual"
+where_style = "Legacy"
+use_try_shorthand = true
+
+# Tabs ***
+
+tab_spaces = 2
+hard_tabs = false
+
+# Spaces ***
+
+space_before_bound = false
+space_after_bound_colon = true
+space_before_type_annotation = false
+space_after_type_annotation_colon = true
+space_after_struct_lit_field_colon = true
+space_before_struct_lit_field_colon = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "faster_path"
 version = "0.0.1"
 dependencies = [
  "array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruby-sys 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruru 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ name = "faster_path"
 crate-type = ["dylib"]
 
 [dependencies]
+ruby-sys = "0.2.20"
 ruru = "0.9.3"
 array_tool = "0.4.1"

--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,7 @@ Rake::TestTask.new(minitest: :build_lib) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task test: [:cargo, :minitest, :lint] do |_t|
+task test: [:cargo, :minitest, :lint, :pbench] do |_t|
   exec 'spec/mspec/bin/mspec --format spec core/file/basename core/file/extname core/file/dirname library/pathname'
 end
 

--- a/faster_path.gemspec
+++ b/faster_path.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 1.12"
   spec.add_dependency "rake", "~> 12.0"
   spec.add_dependency "ffi", "~> 1.9"
-  spec.add_development_dependency "method_source", "~> 0.8.2"
+  spec.add_development_dependency "read_source", "~> 0.2.6"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "minitest-reporters", "~> 1.1"
   spec.add_development_dependency "color_pound_spec_reporter", "~> 0.0.9"

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -18,13 +18,13 @@ module FasterPath
     private :absolute?
     private :add_trailing_separator
     private :basename
-    private :children
-    private :children_compat
+    private :children # String results
+    private :children_compat # wrap Pathname on each
     private :chop_basename
     private :directory?
     private :dirname
-    private :entries
-    private :entries_compat
+    private :entries # String results
+    private :entries_compat # wrap Pathname on each
     private :extname
     private :has_trailing_separator?
     private :plus

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -19,10 +19,12 @@ module FasterPath
     private :add_trailing_separator
     private :basename
     private :children
+    private :children_compat
     private :chop_basename
     private :directory?
     private :dirname
     private :entries
+    private :entries_compat
     private :extname
     private :has_trailing_separator?
     private :plus

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -39,8 +39,8 @@ module FasterPath
         private :add_trailing_separator
 
         def children(with_dir=true)
-          FasterPath.children(@path, with_dir)
-        end
+          FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
+        end if !!ENV['WITH_REGRESSION']
 
         def chop_basename(pth)
           FasterPath.chop_basename(pth)
@@ -52,8 +52,8 @@ module FasterPath
         end
 
         def entries
-          FasterPath.entries(@path)
-        end
+          FasterPathname::Public.allocate.send(:entries_compat, @path)
+        end if !!ENV['WITH_REGRESSION']
 
         def has_trailing_separator?(pth)
           FasterPath.has_trailing_separator?(pth)

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -25,8 +25,6 @@ module FasterPath
         end
       end
     end
-
-    # rubocop:disable Metrics/MethodLength
     def self._ruby_library_pathname!
       ::Pathname.class_eval do
         def absolute?
@@ -38,9 +36,10 @@ module FasterPath
         end
         private :add_trailing_separator
 
-        def children(with_dir=true)
-          FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
-        end if !!ENV['WITH_REGRESSION']
+        # Do NOT remove; waiting for fix in ruru
+        # def children(with_dir=true)
+        #   FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
+        # end if !!ENV['WITH_REGRESSION']
 
         def chop_basename(pth)
           FasterPath.chop_basename(pth)
@@ -51,9 +50,10 @@ module FasterPath
           FasterPath.directory?(@path)
         end
 
-        def entries
-          FasterPathname::Public.allocate.send(:entries_compat, @path)
-        end if !!ENV['WITH_REGRESSION']
+        # Do NOT remove; waiting for fix in ruru
+        # def entries
+        #   FasterPathname::Public.allocate.send(:entries_compat, @path)
+        # end if !!ENV['WITH_REGRESSION']
 
         def has_trailing_separator?(pth)
           FasterPath.has_trailing_separator?(pth)

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -35,8 +35,8 @@ module FasterPath
       private :add_trailing_separator
 
       def children(with_dir=true)
-        FasterPath.children(@path, with_dir)
-      end
+        FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
+      end if !!ENV['WITH_REGRESSION']
 
       def chop_basename(pth)
         FasterPath.chop_basename(pth)
@@ -48,8 +48,8 @@ module FasterPath
       end
 
       def entries
-        FasterPath.entries(@path)
-      end
+        FasterPathname::Public.allocate.send(:entries_compat, @path)
+      end if !!ENV['WITH_REGRESSION']
 
       def has_trailing_separator?(pth)
         FasterPath.has_trailing_separator?(pth)

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -34,9 +34,10 @@ module FasterPath
       end
       private :add_trailing_separator
 
-      def children(with_dir=true)
-        FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
-      end if !!ENV['WITH_REGRESSION']
+      # Do NOT remove; waiting for fix in ruru
+      # def children(with_dir=true)
+      #   FasterPathname::Public.allocate.send(:children_compat, @path, with_dir)
+      # end if !!ENV['WITH_REGRESSION']
 
       def chop_basename(pth)
         FasterPath.chop_basename(pth)
@@ -47,9 +48,10 @@ module FasterPath
         FasterPath.directory?(@path)
       end
 
-      def entries
-        FasterPathname::Public.allocate.send(:entries_compat, @path)
-      end if !!ENV['WITH_REGRESSION']
+      # Do NOT remove; waiting for fix in ruru
+      # def entries
+      #   FasterPathname::Public.allocate.send(:entries_compat, @path)
+      # end if !!ENV['WITH_REGRESSION']
 
       def has_trailing_separator?(pth)
         FasterPath.has_trailing_separator?(pth)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,21 @@
+extern crate ruby_sys;
+use self::ruby_sys::string;
+
+use ruru::{AnyObject, Class};
+use ruru::types::{c_char, c_long, Value};
+
+#[inline]
+pub fn str_to_value(string: &str) -> Value {
+  let str_ptr = string.as_ptr() as *const c_char;
+  let len = string.len() as c_long;
+
+  unsafe { string::rb_str_new(str_ptr, len) }
+}
+
+pub fn str_to_any_obj(str_var: &str) -> AnyObject {
+  AnyObject::from(str_to_value(str_var))
+}
+
+pub fn class_new(klass: &str, params: Vec<AnyObject>) -> AnyObject {
+  Class::from_existing(klass).new_instance(params)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate ruru;
 
 class!(FasterPathname);
 
+mod helpers;
 mod pathname;
 mod basename;
 mod chop_basename;
@@ -26,23 +27,6 @@ methods!(
   FasterPathname,
   _itself,
 
-  // TOPATH = :to_path
-
-  // SAME_PATHS = if File::FNM_SYSCASE.nonzero?
-  //   # Avoid #zero? here because #casecmp can return nil.
-  //   proc {|a, b| a.casecmp(b) == 0}
-  // else
-  //   proc {|a, b| a == b}
-  // end
-
-  // if File::ALT_SEPARATOR
-  //   SEPARATOR_LIST = "#{Regexp.quote File::ALT_SEPARATOR}#{Regexp.quote File::SEPARATOR}"
-  //   SEPARATOR_PAT = /[#{SEPARATOR_LIST}]/
-  // else
-  //   SEPARATOR_LIST = "#{Regexp.quote File::SEPARATOR}"
-  //   SEPARATOR_PAT = /#{Regexp.quote File::SEPARATOR}/
-  // end
-
   fn pub_add_trailing_separator(pth: RString) -> RString {
     pathname::pn_add_trailing_separator(pth)
   }
@@ -59,6 +43,10 @@ methods!(
 
   fn pub_children(pth: RString, with_dir: Boolean) -> Array {
     pathname::pn_children(pth, with_dir)
+  }
+
+  fn pub_children_compat(pth: RString, with_dir: Boolean) -> Array {
+    pathname::pn_children_compat(pth, with_dir)
   }
 
   fn pub_chop_basename(pth: RString) -> Array {
@@ -91,8 +79,14 @@ methods!(
   //   pathname::pn_each_filename(pth)
   // }
 
+  // pub_entries returns an array of String objects
   fn pub_entries(pth: RString) -> Array {
     pathname::pn_entries(pth)
+  }
+
+  // pub_entries_compat returns an array of Pathname objects
+  fn pub_entries_compat(pth: RString) -> Array {
+    pathname::pn_entries_compat(pth)
   }
 
   fn pub_extname(pth: RString) -> RString {
@@ -157,10 +151,12 @@ pub extern "C" fn Init_faster_pathname(){
     itself.def("add_trailing_separator", pub_add_trailing_separator);
     itself.def("basename", pub_basename);
     itself.def("children", pub_children);
+    itself.def("children_compat", pub_children_compat);
     itself.def("chop_basename", pub_chop_basename);
     itself.def("directory?", pub_is_directory);
     itself.def("dirname", pub_dirname);
     itself.def("entries", pub_entries);
+    itself.def("entries_compat", pub_entries_compat);
     itself.def("extname", pub_extname);
     itself.def("has_trailing_separator?", pub_has_trailing_separator);
     itself.def("plus", pub_plus);

--- a/test/benches/children_compat_benchmark.rb
+++ b/test/benches/children_compat_benchmark.rb
@@ -1,0 +1,34 @@
+require "benchmark_helper"
+
+class ChildrenCompatBenchmark < BenchmarkHelper
+  def self.bench_range
+    [20, 40, 60, 80, 100]
+  end
+
+  def setup
+    @file ||= __FILE__
+    @one = "."
+    @two = "../"
+  end
+
+  def teardown
+    super
+    graph_benchmarks
+  end
+
+  def bench_rust_children_compat
+    benchmark :rust do
+      FasterPathname::Public.allocate.send(:children_compat, @one)
+      FasterPathname::Public.allocate.send(:children_compat, @two, false)
+    end
+  end
+
+  def bench_ruby_children______
+    one = Pathname.new(@one)
+    two = Pathname.new(@two)
+    benchmark :ruby do
+      one.children
+      two.children(false)
+    end
+  end
+end

--- a/test/benches/children_compat_benchmark.rb
+++ b/test/benches/children_compat_benchmark.rb
@@ -1,34 +1,36 @@
-require "benchmark_helper"
-
-class ChildrenCompatBenchmark < BenchmarkHelper
-  def self.bench_range
-    [20, 40, 60, 80, 100]
-  end
-
-  def setup
-    @file ||= __FILE__
-    @one = "."
-    @two = "../"
-  end
-
-  def teardown
-    super
-    graph_benchmarks
-  end
-
-  def bench_rust_children_compat
-    benchmark :rust do
-      FasterPathname::Public.allocate.send(:children_compat, @one)
-      FasterPathname::Public.allocate.send(:children_compat, @two, false)
-    end
-  end
-
-  def bench_ruby_children______
-    one = Pathname.new(@one)
-    two = Pathname.new(@two)
-    benchmark :ruby do
-      one.children
-      two.children(false)
-    end
-  end
-end
+# Do NOT remove; waiting for fix in ruru
+#
+# require "benchmark_helper"
+#
+# class ChildrenCompatBenchmark < BenchmarkHelper
+#   def self.bench_range
+#     [20, 40, 60, 80, 100]
+#   end
+#
+#   def setup
+#     @file ||= __FILE__
+#     @one = "."
+#     @two = "../"
+#   end
+#
+#   def teardown
+#     super
+#     graph_benchmarks
+#   end
+#
+#   def bench_rust_children_compat
+#     benchmark :rust do
+#       FasterPathname::Public.allocate.send(:children_compat, @one)
+#       FasterPathname::Public.allocate.send(:children_compat, @two, false)
+#     end
+#   end
+#
+#   def bench_ruby_children______
+#     one = Pathname.new(@one)
+#     two = Pathname.new(@two)
+#     benchmark :ruby do
+#       one.children
+#       two.children(false)
+#     end
+#   end
+# end

--- a/test/benches/entries_compat_benchmark.rb
+++ b/test/benches/entries_compat_benchmark.rb
@@ -1,30 +1,32 @@
-require "benchmark_helper"
-
-class EntriesCompatBenchmark < BenchmarkHelper
-  def setup
-    @file ||= __FILE__
-  end
-
-  def teardown
-    super
-    graph_benchmarks
-  end
-
-  def self.bench_range
-    [2000, 4000, 6000, 8000, 10_000]
-  end
-
-  def bench_rust_entries_compat
-    benchmark :rust do
-      FasterPathname::Public.allocate.send(:entries_compat, ".")
-      FasterPathname::Public.allocate.send(:entries_compat, "src")
-    end
-  end
-
-  def bench_ruby_entries______
-    benchmark :ruby do
-      Pathname.new(".").entries
-      Pathname.new("src").entries
-    end
-  end
-end
+# Do NOT remove; waiting for fix in ruru
+#
+# require "benchmark_helper"
+#
+# class EntriesCompatBenchmark < BenchmarkHelper
+#   def setup
+#     @file ||= __FILE__
+#   end
+#
+#   def teardown
+#     super
+#     graph_benchmarks
+#   end
+#
+#   def self.bench_range
+#     [2000, 4000, 6000, 8000, 10_000]
+#   end
+#
+#   def bench_rust_entries_compat
+#     benchmark :rust do
+#       FasterPathname::Public.allocate.send(:entries_compat, ".")
+#       FasterPathname::Public.allocate.send(:entries_compat, "src")
+#     end
+#   end
+#
+#   def bench_ruby_entries______
+#     benchmark :ruby do
+#       Pathname.new(".").entries
+#       Pathname.new("src").entries
+#     end
+#   end
+# end

--- a/test/benches/entries_compat_benchmark.rb
+++ b/test/benches/entries_compat_benchmark.rb
@@ -1,0 +1,30 @@
+require "benchmark_helper"
+
+class EntriesCompatBenchmark < BenchmarkHelper
+  def setup
+    @file ||= __FILE__
+  end
+
+  def teardown
+    super
+    graph_benchmarks
+  end
+
+  def self.bench_range
+    [2000, 4000, 6000, 8000, 10_000]
+  end
+
+  def bench_rust_entries_compat
+    benchmark :rust do
+      FasterPathname::Public.allocate.send(:entries_compat, ".")
+      FasterPathname::Public.allocate.send(:entries_compat, "src")
+    end
+  end
+
+  def bench_ruby_entries______
+    benchmark :ruby do
+      Pathname.new(".").entries
+      Pathname.new("src").entries
+    end
+  end
+end

--- a/test/children_test.rb
+++ b/test/children_test.rb
@@ -1,10 +1,22 @@
 require 'test_helper'
 
 class ChildrenTest < Minitest::Test
-  def test_it_returns_similar_results_to_pathname_children?
+  def test_pathnames_existing_behavior
+    assert_kind_of Pathname, Pathname.new('.').children.first
+  end
+
+  def test_children_returns_string_objects
+    assert_kind_of String, FasterPath.children('.').first
+  end
+
+  def test_children_compat_returns_pathname_objects
+    assert_kind_of Pathname, FasterPathname::Public.allocate.send(:children_compat, '.').first
+  end
+
+  def test_it_returns_similar_results_to_pathname_children
     [".", "/", "../"].each do |pth|
-      assert_equal Pathname.new(pth).children.map(&:to_s),
-                   FasterPath.children(pth)
+      assert_equal Pathname.new(pth).children,
+        FasterPathname::Public.allocate.send(:children_compat, pth)
     end
   end
 end

--- a/test/children_test.rb
+++ b/test/children_test.rb
@@ -9,14 +9,23 @@ class ChildrenTest < Minitest::Test
     assert_kind_of String, FasterPath.children('.').first
   end
 
-  def test_children_compat_returns_pathname_objects
-    assert_kind_of Pathname, FasterPathname::Public.allocate.send(:children_compat, '.').first
-  end
+  # Do NOT remove; waiting for fix in ruru
+  # def test_children_compat_returns_pathname_objects
+  #   assert_kind_of Pathname, FasterPathname::Public.allocate.send(:children_compat, '.').first
+  # end
 
-  def test_it_returns_similar_results_to_pathname_children
+  # Do NOT remove; waiting for fix in ruru
+  # def test_children_compat_returns_similar_results_to_pathname_children
+  #   [".", "/", "../"].each do |pth|
+  #     assert_equal Pathname.new(pth).children,
+  #       FasterPathname::Public.allocate.send(:children_compat, pth)
+  #   end
+  # end
+
+  def test_children_returns_similar_string_results_to_pathname_children
     [".", "/", "../"].each do |pth|
-      assert_equal Pathname.new(pth).children,
-        FasterPathname::Public.allocate.send(:children_compat, pth)
+      assert_equal Pathname.new(pth).children.map(&:to_s),
+        FasterPathname::Public.allocate.send(:children, pth)
     end
   end
 end

--- a/test/entries_test.rb
+++ b/test/entries_test.rb
@@ -1,10 +1,22 @@
 require 'test_helper'
 
 class EntriesTest < Minitest::Test
+  def test_pathnames_existing_behavior
+    assert_kind_of Pathname, Pathname.new('.').entries.first
+  end
+
+  def test_entries_compat_returns_pathname_objects
+    assert_kind_of Pathname, FasterPathname::Public.allocate.send(:entries_compat, '.').first
+  end
+
+  def test_entries_returns_string_objects
+    assert_kind_of String, FasterPath.entries('.').first
+  end
+
   def test_it_returns_similar_results_to_pathname_entries_as_strings
     ['.', 'lib', 'src'].each do |pth|
-      assert_equal Pathname.new(pth).entries.map(&:to_s).sort,
-                   FasterPath.entries(pth).sort
+      assert_equal Pathname.new(pth).entries.sort,
+        FasterPathname::Public.allocate.send(:entries_compat, pth).sort
     end
   end
 end

--- a/test/entries_test.rb
+++ b/test/entries_test.rb
@@ -5,18 +5,27 @@ class EntriesTest < Minitest::Test
     assert_kind_of Pathname, Pathname.new('.').entries.first
   end
 
-  def test_entries_compat_returns_pathname_objects
-    assert_kind_of Pathname, FasterPathname::Public.allocate.send(:entries_compat, '.').first
-  end
-
   def test_entries_returns_string_objects
     assert_kind_of String, FasterPath.entries('.').first
   end
 
-  def test_it_returns_similar_results_to_pathname_entries_as_strings
+  # Do NOT remove; waiting for fix in ruru
+  # def test_entries_compat_returns_pathname_objects
+  #   assert_kind_of Pathname, FasterPathname::Public.allocate.send(:entries_compat, '.').first
+  # end
+
+  # Do NOT remove; waiting for fix in ruru
+  # def test_entries_compat_returns_similar_results_to_pathname_entries
+  #   ['.', 'lib', 'src'].each do |pth|
+  #     assert_equal Pathname.new(pth).entries.sort,
+  #       FasterPathname::Public.allocate.send(:entries_compat, pth).sort
+  #   end
+  # end
+
+  def test_entries_returns_similar_string_results_to_pathname_entries
     ['.', 'lib', 'src'].each do |pth|
-      assert_equal Pathname.new(pth).entries.sort,
-        FasterPathname::Public.allocate.send(:entries_compat, pth).sort
+      assert_equal Pathname.new(pth).entries.sort.map(&:to_s),
+        FasterPathname::Public.allocate.send(:entries, pth).sort
     end
   end
 end

--- a/test/monkeypatches/faster_path_test.rb
+++ b/test/monkeypatches/faster_path_test.rb
@@ -1,63 +1,65 @@
-require 'test_helper'
-require 'method_source'
-
-if ENV['TEST_MONKEYPATCHES'].to_s['true']
-  require 'faster_path/optional/monkeypatches'
-  FasterPath.sledgehammer_everything!
-end
-
-class MonkeyPatchesTest < Minitest::Test
-  def setup
-    @path = Pathname.new(".")
-  end
+if !RUBY_VERSION["2.4.2"]
+  require 'test_helper'
+  require 'read_source'
 
   if ENV['TEST_MONKEYPATCHES'].to_s['true']
-    def test_it_redefines_absolute?
-      assert @path.method(:absolute?).source[/FasterPath/]
+    require 'faster_path/optional/monkeypatches'
+    FasterPath.sledgehammer_everything!
+  end
+
+  class MonkeyPatchesTest < Minitest::Test
+    def setup
+      @path = Pathname.new(".")
     end
 
-    def test_it_redefines_directory?
-      @path.method(:directory?).source[/FasterPath/]
-    end
+    if ENV['TEST_MONKEYPATCHES'].to_s['true']
+      def test_it_redefines_absolute?
+        assert @path.method(:absolute?).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_chop_basename
-      assert @path.method(:chop_basename).source[/FasterPath/]
-    end
+      def test_it_redefines_directory?
+        @path.method(:directory?).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_relative?
-      assert @path.method(:relative?).source[/FasterPath/]
-    end
+      def test_it_redefines_chop_basename
+        assert @path.method(:chop_basename).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_add_trailing_separator
-      assert @path.method(:add_trailing_separator).source[/FasterPath/]
-    end
+      def test_it_redefines_relative?
+        assert @path.method(:relative?).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_has_trailing_separator
-      assert @path.method(:has_trailing_separator?).source[/FasterPath/]
-    end
-  else
-    def test_it_redefines_absolute?
-      refute @path.method(:absolute?).source[/FasterPath/]
-    end
+      def test_it_redefines_add_trailing_separator
+        assert @path.method(:add_trailing_separator).read_source[/FasterPath/]
+      end
 
-    def test_it_does_not_redefine_directory?
-      assert_raises(MethodSource::SourceNotFoundError){ @path.method(:directory?).source[/FasterPath/] }
-    end
+      def test_it_redefines_has_trailing_separator
+        assert @path.method(:has_trailing_separator?).read_source[/FasterPath/]
+      end
+    else
+      def test_it_redefines_absolute?
+        refute @path.method(:absolute?).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_chop_basename
-      refute @path.method(:chop_basename).source[/FasterPath/]
-    end
+      def test_it_does_not_redefine_directory?
+        assert_raises { @path.method(:directory?).read_source[/FasterPath/] }
+      end
 
-    def test_it_redefines_relative?
-      refute @path.method(:relative?).source[/FasterPath/]
-    end
+      def test_it_redefines_chop_basename
+        refute @path.method(:chop_basename).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_add_trailing_separator
-      refute @path.method(:add_trailing_separator).source[/FasterPath/]
-    end
+      def test_it_redefines_relative?
+        refute @path.method(:relative?).read_source[/FasterPath/]
+      end
 
-    def test_it_redefines_has_trailing_separator
-      refute @path.method(:has_trailing_separator?).source[/FasterPath/]
+      def test_it_redefines_add_trailing_separator
+        refute @path.method(:add_trailing_separator).read_source[/FasterPath/]
+      end
+
+      def test_it_redefines_has_trailing_separator
+        refute @path.method(:has_trailing_separator?).read_source[/FasterPath/]
+      end
     end
   end
 end

--- a/test/output_type_compatibility_test.rb
+++ b/test/output_type_compatibility_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class OutputTypeCompatibilityTest < Minitest::Test
+  ::Minitest::Assertions.module_eval do
+    def assert_same_output_kind(mthd, opt_mthd = nil)
+      a = Pathname.instance_method(mthd).arity
+      args = []
+      a.abs.times do
+        args << "a"
+      end
+
+      b = FasterPath.method(opt_mthd || mthd).arity
+      bargs = []
+      b.abs.times do
+        bargs << "a"
+      end
+
+      pth = Pathname.new("a").send(mthd, *args)
+      fpth = FasterPath.send(opt_mthd || mthd, *bargs)
+      assert_equal pth.is_a?(Array), fpth.is_a?(Array)
+      if pth.is_a?(Array) && fpth.is_a?(Array)
+        assert_equal pth.first.class, fpth.first.class,
+          "Array output kind not equal for method '#{mthd}':\nExpected: #{pth.inspect}\nGot: #{fpth.inspect}"
+      else
+        assert_kind_of pth.class, fpth,
+          "Output kind not equal for method '#{mthd}':\nExpected: #{pth.inspect}\nGot: #{fpth.inspect}"
+      end
+    end
+  end
+
+  describe "test output types are the same" do
+    def test_direct_method_calls
+      mthds = %i[
+        absolute?
+        add_trailing_separator
+        chop_basename
+        directory?
+        has_trailing_separator?
+        plus
+        relative?
+      ]
+
+      mthds.each do |m|
+        assert_same_output_kind(m)
+      end
+    end
+
+    # Do NOT remove; waiting for fix in ruru
+    # def test_compat_methods
+    #   mthds = [
+    #     [:children, :children_compat],
+    #     [:entries, :entries_compat]
+    #   ]
+
+    #   mthds.each do |m|
+    #     assert_same_output_kind(*m)
+    #   end
+    # end
+  end
+
+  describe "test output types are not the same" do
+    def pth
+      "."
+    end
+
+    def test_children
+      refute_equal Pathname.new(pth).children.first.class,
+        FasterPathname::Public.allocate.send(:children, pth).first.class
+    end
+
+    def test_entries
+      refute_equal Pathname.new(pth).entries.first.class,
+        FasterPathname::Public.allocate.send(:entries, pth).first.class
+    end
+  end
+end

--- a/test/pbench/pbench.rb
+++ b/test/pbench/pbench.rb
@@ -55,7 +55,7 @@ class Pbench # < Minitest::Benchmark
     io.send :puts, "-"*80
     io.send :puts, os_lang_specs
     io.send :puts, "-"*80
-    hsh.keys.each do |k|
+    hsh.each_key do |k|
       h = hsh[k]
       result = performance(h[:old], h[:new])
       io.send :puts, "Performance change for #{k} is %.1f%" % result

--- a/test/pbench/pbench_suite.rb
+++ b/test/pbench/pbench_suite.rb
@@ -83,18 +83,19 @@ PBENCHES[:children] = {
     end
   end
 }
-PBENCHES[:children_compat] = {
-  new: lambda do |x|
-    (x/5).times do
-      FasterPathname::Public.allocate.send(:children_compat, '.')
-    end
-  end,
-  old: lambda do |x|
-    (x/5).times do
-      Pathname.new('.').children
-    end
-  end
-}
+# Do NOT remove; waiting for fix in ruru
+# PBENCHES[:children_compat] = {
+#  new: lambda do |x|
+#    (x/5).times do
+#      FasterPathname::Public.allocate.send(:children_compat, '.')
+#    end
+#  end,
+#  old: lambda do |x|
+#    (x/5).times do
+#      Pathname.new('.').children
+#    end
+#  end
+# }
 PBENCHES[:chop_basename] = {
   new: lambda do |x|
     x.times do
@@ -155,20 +156,21 @@ PBENCHES[:entries] = {
     end
   end
 }
-PBENCHES[:entries_compat] = {
-  new: lambda do |x|
-    (x/5).times do
-      FasterPathname::Public.allocate.send(:entries_compat, "./")
-      FasterPathname::Public.allocate.send(:entries_compat, "./src")
-    end
-  end,
-  old: lambda do |x|
-    (x/5).times do
-      Pathname.new("./").entries
-      Pathname.new("./src").entries
-    end
-  end
-}
+# Do NOT remove; waiting for fix in ruru
+# PBENCHES[:entries_compat] = {
+#   new: lambda do |x|
+#     (x/5).times do
+#       FasterPathname::Public.allocate.send(:entries_compat, "./")
+#       FasterPathname::Public.allocate.send(:entries_compat, "./src")
+#     end
+#   end,
+#   old: lambda do |x|
+#     (x/5).times do
+#       Pathname.new("./").entries
+#       Pathname.new("./src").entries
+#     end
+#   end
+# }
 PBENCHES[:extname] = {
   new: lambda do |x|
     x.times do

--- a/test/pbench/pbench_suite.rb
+++ b/test/pbench/pbench_suite.rb
@@ -83,6 +83,18 @@ PBENCHES[:children] = {
     end
   end
 }
+PBENCHES[:children_compat] = {
+  new: lambda do |x|
+    (x/5).times do
+      FasterPathname::Public.allocate.send(:children_compat, '.')
+    end
+  end,
+  old: lambda do |x|
+    (x/5).times do
+      Pathname.new('.').children
+    end
+  end
+}
 PBENCHES[:chop_basename] = {
   new: lambda do |x|
     x.times do
@@ -134,6 +146,20 @@ PBENCHES[:entries] = {
     (x/5).times do
       FasterPath.entries("./")
       FasterPath.entries("./src")
+    end
+  end,
+  old: lambda do |x|
+    (x/5).times do
+      Pathname.new("./").entries
+      Pathname.new("./src").entries
+    end
+  end
+}
+PBENCHES[:entries_compat] = {
+  new: lambda do |x|
+    (x/5).times do
+      FasterPathname::Public.allocate.send(:entries_compat, "./")
+      FasterPathname::Public.allocate.send(:entries_compat, "./src")
     end
   end,
   old: lambda do |x|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 if ENV['TEST_MONKEYPATCHES'] &&
     ENV['WITH_REGRESSION'] &&
+    !ENV['RUST_BACKTRACE'] &&
     ENV['TRAVIS_OS_NAME'] == 'linux' &&
     Gem::Dependency.new('', '~> 2.3', '< 2.4').match?('', RUBY_VERSION)
   require 'simplecov'


### PR DESCRIPTION
* Build compat methods for `entries` and `children`.
* Comment them out as ruru has a segfault for them
* Add a central test file for output compatibility
* Ruby 2.4.2 is wanky so disable monkeypatch tests for that version because of require `method_source` error.  Also switched away from `method_source` gem to `read_source` as it is much smaller, I control it, and perhaps can find a fix for it… note issue still exists in Ruby 2.4.2.
* Update rubocop namespaces
* Add rustfmt preferred styles (not applied)
* Reduce coveralls tests on CI from two to one
* Add pinch benchmark to CI test suite run as the potential ruru segfault issue only occurs occasionally (https://github.com/d-unseductable/ruru/issues/75) .  So until ruru is fixed we need to guard against the possibility of occasional segfaults.