### PR TITLE
Refactor helpers module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ name = "faster_path"
 version = "0.0.1"
 dependencies = [
  "array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruby-sys 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruru 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ name = "faster_path"
 crate-type = ["dylib"]
 
 [dependencies]
-ruby-sys = "0.2.20"
 ruru = "0.9.3"
 array_tool = "0.4.1"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,19 +1,7 @@
-extern crate ruby_sys;
-use self::ruby_sys::string;
-
-use ruru::{AnyObject, Class};
-use ruru::types::{c_char, c_long, Value};
-
-#[inline]
-pub fn str_to_value(string: &str) -> Value {
-  let str_ptr = string.as_ptr() as *const c_char;
-  let len = string.len() as c_long;
-
-  unsafe { string::rb_str_new(str_ptr, len) }
-}
+use ruru::{AnyObject, Class, Object, RString};
 
 pub fn str_to_any_obj(str_var: &str) -> AnyObject {
-  AnyObject::from(str_to_value(str_var))
+  RString::new(str_var).to_any_object()
 }
 
 pub fn class_new(klass: &str, params: Vec<AnyObject>) -> AnyObject {


### PR DESCRIPTION
 - Use ruru API instead of unsafe ruby-sys API for type conversions
 - Remove the explicit ruby-sys dependency from `Cargo.toml`