### PR TITLE
Do not allocate Strings in extname

### DIFF
--- a/src/extname.rs
+++ b/src/extname.rs
@@ -1,13 +1,13 @@
 use path_parsing::extract_last_path_segment;
 
-pub fn extname(pth: &str) -> String {
+pub fn extname(pth: &str) -> &str {
   let name = extract_last_path_segment(pth);
 
   if let Some(dot_i) = name.rfind('.') {
     if dot_i > 0 && dot_i < name.len() - 1 && name[..dot_i].chars().rev().next().unwrap() != '.' {
-      return String::from(&name[dot_i..])
+      return &name[dot_i..]
     }
   }
 
-  String::from("")
+  ""
 }

--- a/src/pathname.rs
+++ b/src/pathname.rs
@@ -177,7 +177,7 @@ pub fn pn_entries_compat(pth: MaybeString) -> Array {
 
 pub fn pn_extname(pth: MaybeString) -> RString {
   RString::new(
-    &extname::extname(pth.ok().unwrap_or(RString::new("")).to_str())[..]
+    extname::extname(pth.ok().unwrap_or(RString::new("")).to_str())
   )
 }
 
@@ -228,4 +228,3 @@ pub fn pn_is_relative(pth: MaybeString) -> Boolean {
 // pub fn pn_rmtree(pth: MaybeString) -> NilClass {
 //   NilClass::new()
 // }
-


### PR DESCRIPTION
 - Use `&str` instead of `String` for `extname::extname`

I've done several passes of `pbench`, it shows the following performance change for `extname`:

 - on `master`, from -5% to 12%;
 - on this branch, from 26% to 37%.