### PR TITLE
Optimize basename and dirname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ name = "faster_path"
 version = "0.0.1"
 dependencies = [
  "array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruru 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -20,6 +21,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ruby-sys"
@@ -42,5 +51,6 @@ dependencies = [
 "checksum array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a07ccb27c611e5cda99e498e99ba71b3ecdb7db5df02096cef42a3df5b84542"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum ruby-sys 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e71509f17ce93733dc196258e168b58050490a156b04563816a8120a74ba04c7"
 "checksum ruru 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6486d6c50b7a08246a492a61893635c1977d41c138041d443eb603f6298e0273"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ name = "faster_path"
 version = "0.0.1"
 dependencies = [
  "array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruru 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -15,6 +16,11 @@ dependencies = [
 [[package]]
 name = "lazy_static"
 version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -50,6 +56,7 @@ dependencies = [
 [metadata]
 "checksum array_tool 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a07ccb27c611e5cda99e498e99ba71b3ecdb7db5df02096cef42a3df5b84542"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum ruby-sys 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e71509f17ce93733dc196258e168b58050490a156b04563816a8120a74ba04c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ crate-type = ["dylib"]
 [dependencies]
 ruru = "0.9.3"
 array_tool = "0.4.1"
+memchr = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ crate-type = ["dylib"]
 [dependencies]
 ruru = "0.9.3"
 array_tool = "0.4.1"
+lazy_static = "1.0"
 memchr = "2.0.1"

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,13 +1,14 @@
 use std::path::MAIN_SEPARATOR;
-use path_parsing::extract_last_path_segment;
+use path_parsing::{last_non_sep_i, last_sep_i};
 
 pub fn basename(pth: &str, ext: &str) -> String {
-  // Known edge case
-  if !pth.is_empty() && pth.bytes().all(|b| b == (MAIN_SEPARATOR as u8)) {
+  let name_end = (last_non_sep_i(pth) + 1) as usize;
+  // Known edge case, all '/'.
+  if !pth.is_empty() && name_end == 0 {
     return MAIN_SEPARATOR.to_string();
   }
 
-  let mut name = extract_last_path_segment(pth);
+  let mut name = &pth[(last_sep_i(pth, name_end as isize) + 1) as usize..name_end];
 
   if ext == ".*" {
     if let Some(dot_i) = name.rfind('.') {

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -8,7 +8,10 @@ pub fn basename<'a>(pth: &'a str, ext: &str) -> &'a str {
   if !pth.is_empty() && name_end == 0 {
     return &pth[..1];
   }
-  let name_start = memrchr(SEP, &pth.as_bytes()[..name_end]).unwrap_or(0);
+  let name_start = match memrchr(SEP, &pth.as_bytes()[..name_end]) {
+    Some(i) => i + 1,
+    _ => 0
+  };
   let mut name = &pth[name_start..name_end];
   if ext == ".*" {
     if let Some(dot_i) = memrchr('.' as u8, name.as_bytes()) {

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,10 +1,11 @@
-extern crate array_tool;
+use std::path::MAIN_SEPARATOR;
 use path_parsing::extract_last_path_segment;
-use self::array_tool::string::Squeeze;
 
 pub fn basename(pth: &str, ext: &str) -> String {
   // Known edge case
-  if &pth.squeeze("/")[..] == "/" { return "/".to_string(); }
+  if !pth.is_empty() && pth.bytes().all(|b| b == (MAIN_SEPARATOR as u8)) {
+    return MAIN_SEPARATOR.to_string();
+  }
 
   let mut name = extract_last_path_segment(pth);
 
@@ -18,3 +19,7 @@ pub fn basename(pth: &str, ext: &str) -> String {
   name.to_string()
 }
 
+#[test]
+fn edge_case_all_seps() {
+  assert_eq!("/", basename("///", ".*"));
+}

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,4 +1,6 @@
-use path_parsing::{last_non_sep_i, last_sep_i};
+extern crate memchr;
+use self::memchr::memrchr;
+use path_parsing::{SEP, last_non_sep_i};
 
 pub fn basename<'a>(pth: &'a str, ext: &str) -> &'a str {
   let name_end = (last_non_sep_i(pth) + 1) as usize;
@@ -6,11 +8,10 @@ pub fn basename<'a>(pth: &'a str, ext: &str) -> &'a str {
   if !pth.is_empty() && name_end == 0 {
     return &pth[..1];
   }
-
-  let mut name = &pth[(last_sep_i(pth, name_end as isize) + 1) as usize..name_end];
-
+  let name_start = memrchr(SEP, &pth.as_bytes()[..name_end]).unwrap_or(0);
+  let mut name = &pth[name_start..name_end];
   if ext == ".*" {
-    if let Some(dot_i) = name.rfind('.') {
+    if let Some(dot_i) = memrchr('.' as u8, name.as_bytes()) {
       name = &name[..dot_i];
     }
   } else if name.ends_with(ext) {

--- a/src/basename.rs
+++ b/src/basename.rs
@@ -1,23 +1,22 @@
-use std::path::MAIN_SEPARATOR;
 use path_parsing::{last_non_sep_i, last_sep_i};
 
-pub fn basename(pth: &str, ext: &str) -> String {
+pub fn basename<'a>(pth: &'a str, ext: &str) -> &'a str {
   let name_end = (last_non_sep_i(pth) + 1) as usize;
   // Known edge case, all '/'.
   if !pth.is_empty() && name_end == 0 {
-    return MAIN_SEPARATOR.to_string();
+    return &pth[..1];
   }
 
   let mut name = &pth[(last_sep_i(pth, name_end as isize) + 1) as usize..name_end];
 
   if ext == ".*" {
     if let Some(dot_i) = name.rfind('.') {
-      name = &name[0..dot_i];
+      name = &name[..dot_i];
     }
   } else if name.ends_with(ext) {
     name = &name[..name.len() - ext.len()];
   };
-  name.to_string()
+  name
 }
 
 #[test]

--- a/src/dirname.rs
+++ b/src/dirname.rs
@@ -1,27 +1,22 @@
-use std::path::MAIN_SEPARATOR;
-use path_parsing::{last_sep_i, last_non_sep_i, last_non_sep_i_before};
+extern crate memchr;
+use self::memchr::memrchr;
+use path_parsing::{SEP, SEP_STR, last_non_sep_i, last_non_sep_i_before};
 
-pub fn dirname(path: &str) -> String {
-  let r_str = path;
-  if r_str.is_empty() {
-    return ".".to_string();
-  }
-  let non_sep_i = last_non_sep_i(r_str);
-  if non_sep_i == -1 {
-    return MAIN_SEPARATOR.to_string();
-  }
-  let sep_i = last_sep_i(r_str, non_sep_i);
-  if sep_i == -1 {
-    return ".".to_string();
-  }
-  if sep_i == 0 {
-    return MAIN_SEPARATOR.to_string();
-  }
-  let non_sep_i2 = last_non_sep_i_before(r_str, sep_i);
-  if non_sep_i2 != -1 {
-    return r_str[..(non_sep_i2 + 1) as usize].to_string();
-  } else {
-    return MAIN_SEPARATOR.to_string();
+pub fn dirname(path: &str) -> &str {
+  if path.is_empty() { return "."; }
+  let non_sep_i = last_non_sep_i(path);
+  if non_sep_i == -1 { return SEP_STR; }
+  return match memrchr(SEP, &path.as_bytes()[..non_sep_i as usize]) {
+    None => ".",
+    Some(0) => SEP_STR,
+    Some(sep_i) => {
+      let non_sep_i2 = last_non_sep_i_before(path, sep_i as isize);
+      if non_sep_i2 != -1 {
+        &path[..(non_sep_i2 + 1) as usize]
+      } else {
+        SEP_STR
+      }
+    }
   }
 }
 

--- a/src/dirname.rs
+++ b/src/dirname.rs
@@ -5,16 +5,16 @@ use path_parsing::{SEP, SEP_STR, last_non_sep_i, last_non_sep_i_before};
 pub fn dirname(path: &str) -> &str {
   if path.is_empty() { return "."; }
   let non_sep_i = last_non_sep_i(path);
-  if non_sep_i == -1 { return SEP_STR; }
+  if non_sep_i == -1 { return *SEP_STR; }
   return match memrchr(SEP, &path.as_bytes()[..non_sep_i as usize]) {
     None => ".",
-    Some(0) => SEP_STR,
+    Some(0) => *SEP_STR,
     Some(sep_i) => {
       let non_sep_i2 = last_non_sep_i_before(path, sep_i as isize);
       if non_sep_i2 != -1 {
         &path[..(non_sep_i2 + 1) as usize]
       } else {
-        SEP_STR
+        *SEP_STR
       }
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 #[macro_use]
 extern crate ruru;
 
+#[macro_use]
+extern crate lazy_static;
+
 class!(FasterPathname);
 
 mod helpers;
@@ -95,7 +98,7 @@ methods!(
 
   // fn r_find(ignore_error: Boolean){}
   // fn pub_find(pth: RString ,ignore_error: Boolean){}
-  
+
   fn pub_has_trailing_separator(pth: RString) -> Boolean {
     pathname::pn_has_trailing_separator(pth)
   }

--- a/src/path_parsing.rs
+++ b/src/path_parsing.rs
@@ -4,8 +4,9 @@ use std::path::MAIN_SEPARATOR;
 use std::str;
 
 pub const SEP: u8 = MAIN_SEPARATOR as u8;
-// TODO: Do not hard-code "/". How can we convert MAIN_SEPARATOR char to a static string here?
-pub static SEP_STR: &'static str = "/";
+lazy_static! {
+  pub static ref SEP_STR: &'static str = str::from_utf8(&[SEP]).unwrap();
+}
 
 pub fn extract_last_path_segment(path: &str) -> &str {
   let end = (last_non_sep_i(path) + 1) as usize;

--- a/src/path_parsing.rs
+++ b/src/path_parsing.rs
@@ -1,6 +1,9 @@
 use std::path::MAIN_SEPARATOR;
+use std::str;
 
-static SEP: u8 = MAIN_SEPARATOR as u8;
+pub const SEP: u8 = MAIN_SEPARATOR as u8;
+// TODO: Do not hard-code "/". How can we convert MAIN_SEPARATOR char to a static string here?
+pub static SEP_STR: &'static str = "/";
 
 pub fn extract_last_path_segment(path: &str) -> &str {
   // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
@@ -39,17 +42,4 @@ pub fn last_non_sep_i_before(path: &str, end: isize) -> isize {
     i -= 1;
   }
   i
-}
-
-// Returns the byte offset of the last MAIN_SEPARATOR before the given end offset.
-pub fn last_sep_i(path: &str, end: isize) -> isize {
-  let ptr = path.as_ptr();
-  let mut i = end - 1;
-  while i >= 0 {
-    if unsafe { *ptr.offset(i) } == SEP {
-      return i;
-    };
-    i -= 1;
-  }
-  -1
 }

--- a/src/path_parsing.rs
+++ b/src/path_parsing.rs
@@ -1,3 +1,5 @@
+extern crate memchr;
+use self::memchr::memrchr;
 use std::path::MAIN_SEPARATOR;
 use std::str;
 
@@ -6,27 +8,9 @@ pub const SEP: u8 = MAIN_SEPARATOR as u8;
 pub static SEP_STR: &'static str = "/";
 
 pub fn extract_last_path_segment(path: &str) -> &str {
-  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
-  // avoid the overhead of full UTF-8 processing.
-  // See src/benches/path_parsing.rs for benchmarks of different approaches.
-  let ptr = path.as_ptr();
-  let mut i = path.len() as isize - 1;
-  while i >= 0 {
-    let c = unsafe { *ptr.offset(i) };
-    if c != SEP { break; };
-    i -= 1;
-  }
-  let end = (i + 1) as usize;
-  while i >= 0 {
-    let c = unsafe { *ptr.offset(i) };
-    if c == SEP {
-      return &path[(i + 1) as usize..end];
-    };
-    i -= 1;
-  }
-  &path[..end]
+  let end = (last_non_sep_i(path) + 1) as usize;
+  &path[memrchr(SEP, &path.as_bytes()[..end]).unwrap_or(0)..end]
 }
-
 
 // Returns the byte offset of the last byte preceding a MAIN_SEPARATOR.
 pub fn last_non_sep_i(path: &str) -> isize {
@@ -35,6 +19,8 @@ pub fn last_non_sep_i(path: &str) -> isize {
 
 // Returns the byte offset of the last byte preceding a MAIN_SEPARATOR before the given end offset.
 pub fn last_non_sep_i_before(path: &str, end: isize) -> isize {
+  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
+  // avoid the overhead of full UTF-8 processing.
   let ptr = path.as_ptr();
   let mut i = end;
   while i >= 0 {

--- a/src/pathname.rs
+++ b/src/pathname.rs
@@ -133,9 +133,9 @@ pub fn pn_is_directory(pth: MaybeString) -> Boolean {
 
 pub fn pn_dirname(pth: MaybeString) -> RString {
   RString::new(
-    &dirname::dirname(
+    dirname::dirname(
       pth.ok().unwrap_or(RString::new("")).to_str()
-    )[..]
+    )
   )
 }
 

--- a/src/pathname.rs
+++ b/src/pathname.rs
@@ -33,10 +33,10 @@ pub fn pn_is_absolute(pth: MaybeString) -> Boolean {
 
 pub fn pn_basename(pth: MaybeString, ext: MaybeString) -> RString {
   RString::new(
-    &basename::basename(
+    basename::basename(
       pth.ok().unwrap_or(RString::new("")).to_str(),
       ext.ok().unwrap_or(RString::new("")).to_str()
-    )[..]
+    )
   )
 }
 

--- a/src/plus.rs
+++ b/src/plus.rs
@@ -73,7 +73,7 @@ pub fn plus_paths(path1: &str, path2: &str) -> String {
     if r1 {
       result = prefix1.to_string();
     } else {
-      result = dirname(&prefix1[..]);
+      result = dirname(&prefix1[..]).to_string();
     }
   }
 


### PR DESCRIPTION
Before: Performance change for basename is -97.7%
After replacing with `bytes()`: -34.5%
After avoiding iteration for the edge check: -30.8%
After returning `&str` instead of String: -25.8%
After using `memrchr` instead of `rfind`: -20%

`dirname` also went from -7% to +7%

Refs #130 