### PR TITLE
Refactor out use of allocate

### DIFF
--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -15,20 +15,20 @@ module FasterPath
     call
 
   FasterPathname::Public.class_eval do
-    private :absolute?
-    private :add_trailing_separator
-    private :basename
-    private :children # String results
-    private :children_compat # wrap Pathname on each
-    private :chop_basename
-    private :directory?
-    private :dirname
-    private :entries # String results
-    private :entries_compat # wrap Pathname on each
-    private :extname
-    private :has_trailing_separator?
-    private :plus
-    private :relative?
+    private_class_method :absolute?
+    private_class_method :add_trailing_separator
+    private_class_method :basename
+    private_class_method :children # String results
+    private_class_method :children_compat # wrap Pathname on each
+    private_class_method :chop_basename
+    private_class_method :directory?
+    private_class_method :dirname
+    private_class_method :entries # String results
+    private_class_method :entries_compat # wrap Pathname on each
+    private_class_method :extname
+    private_class_method :has_trailing_separator?
+    private_class_method :plus
+    private_class_method :relative?
   end
 
   FasterPathname.class_eval do
@@ -60,11 +60,11 @@ module FasterPath
   end
 
   def self.absolute?(pth)
-    FasterPathname::Public.allocate.send(:absolute?, pth)
+    FasterPathname::Public.send(:absolute?, pth)
   end
 
   def self.add_trailing_separator(pth)
-    FasterPathname::Public.allocate.send(:add_trailing_separator, pth)
+    FasterPathname::Public.send(:add_trailing_separator, pth)
   end
 
   def self.blank?(str)
@@ -72,44 +72,44 @@ module FasterPath
   end
 
   def self.basename(pth, ext="")
-    FasterPathname::Public.allocate.send(:basename, pth, ext)
+    FasterPathname::Public.send(:basename, pth, ext)
   end
 
   def self.children(pth, with_directory=true)
-    FasterPathname::Public.allocate.send(:children, pth, with_directory)
+    FasterPathname::Public.send(:children, pth, with_directory)
   end
 
   def self.chop_basename(pth)
-    result = FasterPathname::Public.allocate.send(:chop_basename, pth)
+    result = FasterPathname::Public.send(:chop_basename, pth)
     result unless result.empty?
   end
 
   def self.directory?(pth)
-    FasterPathname::Public.allocate.send(:directory?, pth)
+    FasterPathname::Public.send(:directory?, pth)
   end
 
   def self.dirname(pth)
-    FasterPathname::Public.allocate.send(:dirname, pth)
+    FasterPathname::Public.send(:dirname, pth)
   end
 
   def self.entries(pth)
-    FasterPathname::Public.allocate.send(:entries, pth)
+    FasterPathname::Public.send(:entries, pth)
   end
 
   def self.extname(pth)
-    FasterPathname::Public.allocate.send(:extname, pth)
+    FasterPathname::Public.send(:extname, pth)
   end
 
   def self.has_trailing_separator?(pth)
-    FasterPathname::Public.allocate.send(:has_trailing_separator?, pth)
+    FasterPathname::Public.send(:has_trailing_separator?, pth)
   end
 
   def self.plus(pth, pth2)
-    FasterPathname::Public.allocate.send(:plus, pth, pth2)
+    FasterPathname::Public.send(:plus, pth, pth2)
   end
 
   def self.relative?(pth)
-    FasterPathname::Public.allocate.send(:relative?, pth)
+    FasterPathname::Public.send(:relative?, pth)
   end
 
   module Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ methods!(
 
   // fn r_find(ignore_error: Boolean){}
   // fn pub_find(pth: RString ,ignore_error: Boolean){}
-  
+
   fn pub_has_trailing_separator(pth: RString) -> Boolean {
     pathname::pn_has_trailing_separator(pth)
   }
@@ -147,19 +147,19 @@ pub extern "C" fn Init_faster_pathname(){
   // * methods for refinements, monkeypatching
   // * methods that need all values as parameters
   Class::from_existing("FasterPathname").get_nested_class("Public").define(|itself| {
-    itself.def("absolute?", pub_is_absolute);
-    itself.def("add_trailing_separator", pub_add_trailing_separator);
-    itself.def("basename", pub_basename);
-    itself.def("children", pub_children);
-    itself.def("children_compat", pub_children_compat);
-    itself.def("chop_basename", pub_chop_basename);
-    itself.def("directory?", pub_is_directory);
-    itself.def("dirname", pub_dirname);
-    itself.def("entries", pub_entries);
-    itself.def("entries_compat", pub_entries_compat);
-    itself.def("extname", pub_extname);
-    itself.def("has_trailing_separator?", pub_has_trailing_separator);
-    itself.def("plus", pub_plus);
-    itself.def("relative?", pub_is_relative);
+    itself.def_self("absolute?", pub_is_absolute);
+    itself.def_self("add_trailing_separator", pub_add_trailing_separator);
+    itself.def_self("basename", pub_basename);
+    itself.def_self("children", pub_children);
+    itself.def_self("children_compat", pub_children_compat);
+    itself.def_self("chop_basename", pub_chop_basename);
+    itself.def_self("directory?", pub_is_directory);
+    itself.def_self("dirname", pub_dirname);
+    itself.def_self("entries", pub_entries);
+    itself.def_self("entries_compat", pub_entries_compat);
+    itself.def_self("extname", pub_extname);
+    itself.def_self("has_trailing_separator?", pub_has_trailing_separator);
+    itself.def_self("plus", pub_plus);
+    itself.def_self("relative?", pub_is_relative);
   });
 }

--- a/test/children_test.rb
+++ b/test/children_test.rb
@@ -25,7 +25,7 @@ class ChildrenTest < Minitest::Test
   def test_children_returns_similar_string_results_to_pathname_children
     [".", "/", "../"].each do |pth|
       assert_equal Pathname.new(pth).children.map(&:to_s),
-        FasterPathname::Public.allocate.send(:children, pth)
+        FasterPathname::Public.send(:children, pth)
     end
   end
 end

--- a/test/entries_test.rb
+++ b/test/entries_test.rb
@@ -25,7 +25,7 @@ class EntriesTest < Minitest::Test
   def test_entries_returns_similar_string_results_to_pathname_entries
     ['.', 'lib', 'src'].each do |pth|
       assert_equal Pathname.new(pth).entries.sort.map(&:to_s),
-        FasterPathname::Public.allocate.send(:entries, pth).sort
+        FasterPathname::Public.send(:entries, pth).sort
     end
   end
 end

--- a/test/output_type_compatibility_test.rb
+++ b/test/output_type_compatibility_test.rb
@@ -65,12 +65,12 @@ class OutputTypeCompatibilityTest < Minitest::Test
 
     def test_children
       refute_equal Pathname.new(pth).children.first.class,
-        FasterPathname::Public.allocate.send(:children, pth).first.class
+        FasterPathname::Public.send(:children, pth).first.class
     end
 
     def test_entries
       refute_equal Pathname.new(pth).entries.first.class,
-        FasterPathname::Public.allocate.send(:entries, pth).first.class
+        FasterPathname::Public.send(:entries, pth).first.class
     end
   end
 end


### PR DESCRIPTION
 - Define class methods instead of instance methods for `FasterPathname::Public`
 - Do not use `Public.allocate`

Resolves #131.