### PR TITLE
Improve `basename` and `dirname`

### DIFF
--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -10,7 +10,7 @@ module FasterPath
           pth = pth.to_path if pth.respond_to? :to_path
           raise TypeError unless pth.is_a?(String) && ext.is_a?(String)
           FasterPath.basename(pth, ext)
-        end if !!ENV['WITH_REGRESSION']
+        end
 
         def self.extname(pth)
           pth = pth.to_path if pth.respond_to? :to_path
@@ -22,7 +22,7 @@ module FasterPath
           pth = pth.to_path if pth.respond_to? :to_path
           raise TypeError unless pth.is_a? String
           FasterPath.dirname(pth)
-        end if !!ENV['WITH_REGRESSION']
+        end
       end
     end
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod pathname_sys;
 mod plus;
 mod prepend_prefix;
 pub mod rust_arch_bits;
+mod memrnchr;
 mod path_parsing;
 mod relative_path_from;
 

--- a/src/memrnchr.rs
+++ b/src/memrnchr.rs
@@ -1,0 +1,93 @@
+// The code below is based on the fallback `memrchr` implementation from the respective crate.
+//
+// We use this mainly to skip repeated `/`. If there is only one slash, `memrnchr` performs the same
+// as a naive version (e.g. `rposition`). However, it is much faster in pathological cases.
+
+const LO_U64: u64 = 0x0101010101010101;
+const HI_U64: u64 = 0x8080808080808080;
+
+// use truncation
+const LO_USIZE: usize = LO_U64 as usize;
+const HI_USIZE: usize = HI_U64 as usize;
+
+#[cfg(target_pointer_width = "32")]
+const USIZE_BYTES: usize = 4;
+#[cfg(target_pointer_width = "64")]
+const USIZE_BYTES: usize = 8;
+
+// Returns the byte offset of the last byte that is NOT equal to the given one.
+#[inline(always)]
+pub fn memrnchr(x: u8, text: &[u8]) -> Option<usize> {
+  // Scan for a single byte value by reading two `usize` words at a time.
+  //
+  // Split `text` in three parts
+  // - unaligned tail, after the last word aligned address in text
+  // - body, scan by 2 words at a time
+  // - the first remaining bytes, < 2 word size
+  let len = text.len();
+  let ptr = text.as_ptr();
+
+  // search to an aligned boundary
+  let end_align = (ptr as usize + len) & (USIZE_BYTES - 1);
+  let mut offset;
+  if end_align > 0 {
+    offset = if end_align >= len { 0 } else { len - end_align };
+    let pos = text[offset..].iter().rposition(|elt| *elt != x);
+    if let Some(index) = pos {
+      return Some(offset + index);
+    }
+  } else {
+    offset = len;
+  }
+
+  // search the body of the text
+  let repeated_x = repeat_byte(x);
+
+  while offset >= 2 * USIZE_BYTES {
+    debug_assert_eq!((ptr as usize + offset) % USIZE_BYTES, 0);
+    unsafe {
+      let u = *(ptr.offset(offset as isize - 2 * USIZE_BYTES as isize) as *const usize);
+      let v = *(ptr.offset(offset as isize - USIZE_BYTES as isize) as *const usize);
+
+      // break if there is a matching byte
+      let zu = contains_zero_byte(u ^ repeated_x);
+      let zv = contains_zero_byte(v ^ repeated_x);
+      if !zu || !zv {
+        break;
+      }
+    }
+    offset -= 2 * USIZE_BYTES;
+  }
+
+  // find the byte before the point the body loop stopped
+  text[..offset].iter().rposition(|elt| *elt != x)
+}
+
+/// Return `true` if `x` contains any zero byte.
+///
+/// From *Matters Computational*, J. Arndt
+///
+/// "The idea is to subtract one from each of the bytes and then look for
+/// bytes where the borrow propagated all the way to the most significant
+/// bit."
+#[inline]
+fn contains_zero_byte(x: usize) -> bool {
+  x.wrapping_sub(LO_USIZE) & !x & HI_USIZE != 0
+}
+
+#[cfg(target_pointer_width = "32")]
+#[inline]
+fn repeat_byte(b: u8) -> usize {
+  let mut rep = (b as usize) << 8 | b as usize;
+  rep = rep << 16 | rep;
+  rep
+}
+
+#[cfg(target_pointer_width = "64")]
+#[inline]
+fn repeat_byte(b: u8) -> usize {
+  let mut rep = (b as usize) << 8 | b as usize;
+  rep = rep << 16 | rep;
+  rep = rep << 32 | rep;
+  rep
+}

--- a/src/path_parsing.rs
+++ b/src/path_parsing.rs
@@ -1,4 +1,7 @@
 extern crate memchr;
+
+use self::memchr::memrchr;
+use memrnchr::memrnchr;
 use std::path::MAIN_SEPARATOR;
 use std::str;
 
@@ -7,20 +10,20 @@ lazy_static! {
   pub static ref SEP_STR: &'static str = str::from_utf8(&[SEP]).unwrap();
 }
 
-// Returns the byte offset of the last byte preceding a MAIN_SEPARATOR.
-pub fn last_non_sep_i(path: &str) -> isize {
-  last_non_sep_i_before(path, path.len() as isize - 1)
+// Returns the byte offset of the last byte that equals MAIN_SEPARATOR.
+#[inline(always)]
+pub fn find_last_dot_pos(bytes: &[u8]) -> Option<usize> {
+  memrchr(b'.', bytes)
 }
 
-// Returns the byte offset of the last byte preceding a MAIN_SEPARATOR before the given end offset.
-pub fn last_non_sep_i_before(path: &str, end: isize) -> isize {
-  // Works with bytes directly because MAIN_SEPARATOR is always in the ASCII 7-bit range so we can
-  // avoid the overhead of full UTF-8 processing.
-  let ptr = path.as_ptr();
-  let mut i = end;
-  while i >= 0 {
-    if unsafe { *ptr.offset(i) } != SEP { break; };
-    i -= 1;
-  }
-  i
+// Returns the byte offset of the last byte that equals MAIN_SEPARATOR.
+#[inline(always)]
+pub fn find_last_sep_pos(bytes: &[u8]) -> Option<usize> {
+  memrchr(SEP, bytes)
+}
+
+// Returns the byte offset of the last byte that is not MAIN_SEPARATOR.
+#[inline(always)]
+pub fn find_last_non_sep_pos(bytes: &[u8]) -> Option<usize> {
+  memrnchr(SEP, bytes)
 }

--- a/test/benches/dirname_benchmark.rb
+++ b/test/benches/dirname_benchmark.rb
@@ -11,7 +11,7 @@ class DirnameBenchmark < BenchmarkHelper
   end
 
   def bench_ruby_dirname
-    benchmark :rust do
+    benchmark :ruby do
       File.dirname "/really/long/path/name/which/ruby/doesnt/like/bar.txt"
       File.dirname "/foo/"
       File.dirname "."
@@ -19,7 +19,7 @@ class DirnameBenchmark < BenchmarkHelper
   end
 
   def bench_rust_dirname
-    benchmark :ruby do
+    benchmark :rust do
       FasterPath.dirname "/really/long/path/name/which/ruby/doesnt/like/bar.txt"
       FasterPath.dirname "/foo/"
       FasterPath.dirname "."


### PR DESCRIPTION
A faster and more readable implementation of `basename` and `dirname`.

![basename_benchmark](https://user-images.githubusercontent.com/216339/37260509-ded465d8-258b-11e8-9349-80c9b9aa47d2.png)
![dirname_benchmark](https://user-images.githubusercontent.com/216339/37260512-e11ebbf4-258b-11e8-8473-69ed5116a69a.png)
