### PR TITLE
Reduce allocations in `prepend_prefix`

### DIFF
--- a/src/prepend_prefix.rs
+++ b/src/prepend_prefix.rs
@@ -1,17 +1,18 @@
+extern crate memchr;
+use self::memchr::memchr;
 use dirname::dirname;
-use basename::basename;
-use std::path::MAIN_SEPARATOR as SEP;
+use path_parsing::SEP;
 
 pub fn prepend_prefix(prefix: &str, relpath: &str) -> String {
-  let mut prefix: String = prefix.to_string();
   if relpath.is_empty() {
-    dirname(&prefix).to_string()
-  } else if prefix.contains(&SEP.to_string()[..]) {
-    prefix = dirname(&prefix).to_string();
-    if basename(&format!("{}{}", &prefix, "a"), "") != "a" {
-      prefix = format!("{}{}", prefix, &SEP);
+    dirname(prefix).to_string()
+  } else if memchr(SEP, prefix.as_bytes()) != None {
+    let prefix_dirname = dirname(prefix);
+    match prefix_dirname.as_bytes().last() {
+      None => relpath.to_string(),
+      Some(&SEP) => format!("{}{}", prefix_dirname, relpath),
+      _ => format!("{}{}{}", prefix_dirname, SEP, relpath)
     }
-    format!("{}{}", prefix, relpath)
   } else {
     format!("{}{}", prefix, relpath)
   }


### PR DESCRIPTION
Performance change for:
  * cleanpath_aggressive 69.6% -> 73.0%
  * cleanpath_conservative 72.7% -> 73.7%

Note that the `cleanpath*` functions still do *a lot* of unnecessary heap allocations  via `to_string()`.