### PR TITLE
Various performance improvements to pathname

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,9 @@
 use ruru::{RString, Object, Class, AnyObject};
 extern crate ruby_sys;
 use debug::RubyDebugInfo;
+use ruru;
+
+type MaybeString = Result<ruru::RString, ruru::result::Error>;
 
 pub trait TryFrom<T>: Sized {
   type Error;
@@ -22,17 +25,24 @@ pub fn anyobject_to_string(item: AnyObject) -> Result<String, RubyDebugInfo> {
   if Class::from_existing("String").case_equals(result) {
     return Ok(RString::from(result.value()).to_string())
   }
-  
+
   if Class::from_existing("Pathname").case_equals(result) {
     return Ok(result.instance_variable_get("@path").
       try_convert_to::<RString>().
       unwrap_or(RString::new("")).
       to_string())
   }
-  
+
   if result.respond_to("to_path") {
     return Ok(RString::from(result.send("to_path", None).value()).to_string())
   }
 
   Ok(RString::from(result.send("to_s", None).value()).to_string())
+}
+
+pub fn to_str(maybe_string: &MaybeString) -> &str {
+  match maybe_string {
+    &Ok(ref ruru_string) => ruru_string.to_str(),
+    &Err(_) => "",
+  }
 }


### PR DESCRIPTION
1. Avoids unnecessary String allocations.
2. Reserve Array capacity when possible.
3. Avoid `Char` in favour of `u8` when possible.
4. `.ok().unwrap` -> `.unwrap`.

Travis benchmark:

Before: https://travis-ci.org/danielpclark/faster_path/jobs/352457728

```
64-bit ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
64-bit rustc 1.24.1 (d3ae9a9e0 2018-02-27)
architecture: x86_64-unknown-linux-gnu
--------------------------------------------------------------------------------
Performance change for allocate, instead of new, is 77.5%
Performance change for absolute? is 88.5%
Performance change for add_trailing_separator is 39.3%
Performance change for basename is 1.8%
Performance change for children is 43.5%
Performance change for children_compat is -56.7%
Performance change for chop_basename is 78.0%
Performance change for cleanpath_aggressive is 92.0%
Performance change for cleanpath_conservative is 91.7%
Performance change for del_trailing_separator is 85.0%
Performance change for directory? is 2.0%
Performance change for dirname is 26.5%
Performance change for entries is 53.0%
Performance change for entries_compat is -102.6%
Performance change for extname is 66.4%
Performance change for has_trailing_separator? is 84.2%
Performance change for join is 71.9%
Performance change for plus is 86.6%
Performance change for relative? is 87.1%
Performance change for relative_path_from is 84.7%
```

After:

```
Performance change for allocate, instead of new, is 76.1%
Performance change for absolute? is 95.7%
Performance change for add_trailing_separator is 50.8%
Performance change for basename is 7.8%
Performance change for children is 34.6%
Performance change for children_compat is -37.4%
Performance change for chop_basename is 82.4%
Performance change for cleanpath_aggressive is 93.4%
Performance change for cleanpath_conservative is 93.1%
Performance change for del_trailing_separator is 89.5%
Performance change for directory? is 17.6%
Performance change for dirname is 52.8%
Performance change for entries is 27.6%
Performance change for entries_compat is -99.9%
Performance change for extname is 65.5%
Performance change for has_trailing_separator? is 90.3%
Performance change for join is 67.0%
Performance change for plus is 87.7%
Performance change for relative? is 93.6%
Performance change for relative_path_from is 91.0%
```