### PR TITLE
Changed ruby-sys & ruru. libruby copy not required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = "array_tool"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "faster_path"
 version = "0.0.1"
 dependencies = [
- "array_tool 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "array_tool 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruby-sys 0.3.0 (git+https://github.com/danielpclark/ruby-sys?branch=playground)",
@@ -26,7 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.37"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -34,31 +34,31 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ruby-sys"
 version = "0.3.0"
-source = "git+https://github.com/danielpclark/ruby-sys?branch=playground#184a3cd3bd39b525ff956f7cba1770bbf1522d8b"
+source = "git+https://github.com/danielpclark/ruby-sys?branch=playground#a3d47da5f9d1e597c62a8f03fb7d3a3596393c47"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ruru"
 version = "0.9.3"
-source = "git+https://github.com/danielpclark/ruru?branch=playground#c9b59118ebcf034874d491a0c1f3b57ef05c183a"
+source = "git+https://github.com/danielpclark/ruru?branch=playground#ab84ad4b97c41bfe6fd6d0f8540b2efd77583561"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruby-sys 0.3.0 (git+https://github.com/danielpclark/ruby-sys?branch=playground)",
 ]
 
 [metadata]
-"checksum array_tool 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7894b81e06d8a2376f015b34dd89770c549932ff90bba6427f7cd83243bb629b"
+"checksum array_tool 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "56aebce561378d99a0bb578f8cb15b6114d2a1814a6c7949bbe646d968bb4fa9"
+"checksum libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)" = "f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum ruby-sys 0.3.0 (git+https://github.com/danielpclark/ruby-sys?branch=playground)" = "<none>"
 "checksum ruru 0.9.3 (git+https://github.com/danielpclark/ruru?branch=playground)" = "<none>"

--- a/Rakefile
+++ b/Rakefile
@@ -31,36 +31,6 @@ task :contrib do
 ' > Contributors.md;git shortlog -s -n -e | sed 's/^......./- /' >> Contributors.md"
 end
 
-desc "Add libruby to deps"
-task :libruby_release do
-  filename = RbConfig::CONFIG["LIBRUBY_ALIASES"].split(" ").first
-  libfile = File.join(RbConfig::CONFIG["libdir"], filename)
-  deps = "target/release/deps"
-
-  printf "Copying libruby.so ... "
-  unless File.exist? "#{deps}/#{filename}"
-    FileUtils.mkdir_p deps
-    FileUtils.cp libfile, deps
-  end
-  exit 1 unless File.exist? "#{deps}/#{filename}"
-  puts "libruby.so copied."
-end
-
-desc "Add libruby to debug deps"
-task :libruby_debug do
-  filename = RbConfig::CONFIG["LIBRUBY_ALIASES"].split(" ").first
-  libfile = File.join(RbConfig::CONFIG["libdir"], filename)
-  deps = "target/debug/deps"
-
-  printf "Copying libruby.so ... "
-  unless File.exist? "#{deps}/#{filename}"
-    FileUtils.mkdir_p deps
-    FileUtils.cp libfile, deps
-  end
-  exit 1 unless File.exist? "#{deps}/#{filename}"
-  puts "libruby.so copied."
-end
-
 desc 'Build + clean up Rust extension'
 task build_lib: 'thermite:build' do
   thermite.run_cargo 'clean'
@@ -75,7 +45,7 @@ task :lint do
 end
 
 desc "Run Rust Tests"
-task cargo: :libruby_debug do
+task :cargo do
   sh "cargo test -- --nocapture"
 end
 

--- a/lib/faster_path.rb
+++ b/lib/faster_path.rb
@@ -5,6 +5,9 @@ require 'faster_path/thermite_initialize'
 require 'fiddle'
 require 'fiddle/import'
 
+# FasterPath module behaves as a singleton object with the alternative method
+# implementations for Pathname, and some for File, available directly on it.
+#
 module FasterPath
   FFI_LIBRARY = begin
     toplevel_dir = File.dirname(__dir__)
@@ -23,30 +26,50 @@ module FasterPath
     private_class_method :children_compat
   end
 
+  # The Rust architecture bit width: 64bits or 32bits
+  # @return [Integer]
   def self.rust_arch_bits
     Rust.rust_arch_bits
   end
 
+  # The Ruby architecture bit width: 64bits or 32bits
+  # @return [Integer]
   def self.ruby_arch_bits
     1.size * 8
   end
 
+  # A very fast way to check if a string is blank
+  # @param str [#to_s]
+  # @return [true, false]
   def self.blank?(str)
     "#{str}".strip.empty?
   end
 
+  # Rust implementation of File.basename
+  # @param pth [String] the path to evaluate
+  # @param ext [String] any extension to remove
+  # @return [String]
   def self.basename(pth, ext="")
     Public.send(:basename, pth, ext)
   end
 
+  # Rust implementation of Pathname.children
+  # @param pth [String] the path to evaluate
+  # @param with_directory [true, false] whether to include directory in results
+  # @return [Array<String>]
   def self.children(pth, with_directory=true)
     Public.send(:children, pth, with_directory)
   end
 
+  # Rust implementation of Pathname.children
+  # @param pth [String] the path to evaluate
+  # @param with_directory [true, false] whether to include directory in results
+  # @return [Array<Pathname>]
   def self.children_compat(pth, with_directory=true)
     Public.send(:children_compat, pth, with_directory)
   end
 
+  # @private
   module Rust
     extend Fiddle::Importer
     dlload FFI_LIBRARY

--- a/lib/faster_path/optional/monkeypatches.rb
+++ b/lib/faster_path/optional/monkeypatches.rb
@@ -1,23 +1,29 @@
 require 'pathname'
 
+# :nodoc:
 module FasterPath
+  # Core module for applying monkeypatches to `Pathname` and `File`
   module MonkeyPatches
+    # Monkeypatch just `File` specific methods
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     def self._ruby_core_file!
       ::File.class_eval do
+        # @private :nodoc:
         def self.basename(pth, ext = '')
           pth = pth.to_path if pth.respond_to? :to_path
           raise TypeError unless pth.is_a?(String) && ext.is_a?(String)
           FasterPath.basename(pth, ext)
         end
 
+        # @private :nodoc:
         def self.extname(pth)
           pth = pth.to_path if pth.respond_to? :to_path
           raise TypeError unless pth.is_a? String
           FasterPath.extname(pth)
         end
 
+        # @private :nodoc:
         def self.dirname(pth)
           pth = pth.to_path if pth.respond_to? :to_path
           raise TypeError unless pth.is_a? String
@@ -26,68 +32,83 @@ module FasterPath
       end
     end
 
+    # Monkeypatch just `Pathname` specific methods
     # rubocop:disable Metrics/MethodLength
     def self._ruby_library_pathname!
       ::Pathname.class_eval do
+        # @private :nodoc:
         def absolute?
           FasterPath.absolute?(@path)
         end
 
+        # @private :nodoc:
         def add_trailing_separator(pth)
           FasterPath.add_trailing_separator(pth)
         end
         private :add_trailing_separator
 
+        # @private :nodoc:
         def children(with_dir=true)
           FasterPath.children_compat(@path, with_dir)
         end if !!ENV['WITH_REGRESSION']
 
+        # @private :nodoc:
         def chop_basename(pth)
           FasterPath.chop_basename(pth)
         end
         private :chop_basename
 
+        # @private :nodoc:
         def cleanpath_aggressive
           Pathname.new(FasterPath.cleanpath_aggressive(@path))
         end
         private :cleanpath_aggressive
 
+        # @private :nodoc:
         def cleanpath_conservative
           Pathname.new(FasterPath.cleanpath_conservative(@path))
         end
         private :cleanpath_conservative
 
+        # @private :nodoc:
         def del_trailing_separator(pth)
           FasterPath.del_trailing_separator(pth)
         end
         private :del_trailing_separator
 
+        # @private :nodoc:
         def directory?
           FasterPath.directory?(@path)
         end
 
+        # @private :nodoc:
         def entries
           FasterPath.entries_compat(@path)
         end if !!ENV['WITH_REGRESSION']
 
+        # @private :nodoc:
         def has_trailing_separator?(pth)
           FasterPath.has_trailing_separator?(pth)
         end
         private :has_trailing_separator?
 
+        # @private :nodoc:
         def join(*args)
           FasterPath.join(self, *args)
         end
 
+        # @private :nodoc:
         def plus(pth, pth2)
           FasterPath.plus(pth, pth2)
         end
         private :plus
 
+        # @private :nodoc:
         def relative?
           FasterPath.relative?(@path)
         end
 
+        # @private :nodoc:
         def relative_path_from(other)
           FasterPath.relative_path_from(@path, other)
         end
@@ -96,9 +117,9 @@ module FasterPath
   end
   private_constant :MonkeyPatches
 
-  def self.sledgehammer_everything!()
+  # Applies all performant monkeypatches to both `Pathname` and `File`
+  def self.sledgehammer_everything!
     MonkeyPatches._ruby_core_file!
     MonkeyPatches._ruby_library_pathname!
-    "CAUTION: Monkey patching effects everything! Be very sure you want this!"
   end
 end

--- a/lib/faster_path/optional/refinements.rb
+++ b/lib/faster_path/optional/refinements.rb
@@ -1,20 +1,25 @@
 require 'pathname'
 
+# @private :nodoc:
 module FasterPath
+  # @private :nodoc:
   module RefineFile
     refine File do
+      # @private :nodoc:
       def self.basename(pth, ext = '')
         pth = pth.to_path if pth.respond_to? :to_path
         raise TypeError unless pth.is_a?(String) && ext.is_a?(String)
         FasterPath.basename(pth, ext)
       end
 
+      # @private :nodoc:
       def self.extname(pth)
         pth = pth.to_path if pth.respond_to? :to_path
         raise TypeError unless pth.is_a? String
         FasterPath.extname(pth)
       end
 
+      # @private :nodoc:
       def self.dirname(pth)
         pth = pth.to_path if pth.respond_to? :to_path
         raise TypeError unless pth.is_a? String
@@ -23,66 +28,81 @@ module FasterPath
     end
   end
 
+  # @private :nodoc:
   module RefinePathname
     refine Pathname do
+      # @private :nodoc:
       def absolute?
         FasterPath.absolute?(@path)
       end
 
+      # @private :nodoc:
       def add_trailing_separator(pth)
         FasterPath.add_trailing_separator(pth)
       end
       private :add_trailing_separator
 
+      # @private :nodoc:
       def children(with_dir=true)
         FasterPath.children_compat(@path, with_dir)
       end if !!ENV['WITH_REGRESSION']
 
+      # @private :nodoc:
       def chop_basename(pth)
         FasterPath.chop_basename(pth)
       end
       private :chop_basename
 
+      # @private :nodoc:
       def cleanpath_aggressive
         Pathname.new(FasterPath.cleanpath_aggressive(@path))
       end
       private :cleanpath_aggressive
 
+      # @private :nodoc:
       def cleanpath_conservative
         Pathname.new(FasterPath.cleanpath_conservative(@path))
       end
       private :cleanpath_conservative
 
+      # @private :nodoc:
       def del_trailing_separator(pth)
         FasterPath.del_trailing_separator(pth)
       end
       private :del_trailing_separator
 
+      # @private :nodoc:
       def directory?
         FasterPath.directory?(@path)
       end
 
+      # @private :nodoc:
       def entries
         FasterPath.entries_compat(@path)
       end if !!ENV['WITH_REGRESSION']
 
+      # @private :nodoc:
       def has_trailing_separator?(pth)
         FasterPath.has_trailing_separator?(pth)
       end
 
+      # @private :nodoc:
       def join(*args)
         FasterPath.join(self, *args)
       end
 
+      # @private :nodoc:
       def plus(pth, pth2)
         FasterPath.plus(pth, pth2)
       end
       private :plus
 
+      # @private :nodoc:
       def relative?
         FasterPath.relative?(@path)
       end
 
+      # @private :nodoc:
       def relative_path_from(other)
         FasterPath.relative_path_from(@path, other)
       end

--- a/lib/faster_path/thermite_initialize.rb
+++ b/lib/faster_path/thermite_initialize.rb
@@ -2,14 +2,19 @@ require 'rubygems'
 require 'rake/tasklib'
 require_relative './version'
 
+# @private :nodoc:
 module Thermite
+  # @private :nodoc:
   class Config
+    # @private :nodoc:
     def ruby_version
       "ruby#{RUBY_VERSION}"
     end
   end
 
+  # @private :nodoc:
   class Tasks < Rake::TaskLib
+    # @private :nodoc:
     def github_download_uri(_tag, version)
       "#{github_uri}/releases/download/v#{FasterPath::VERSION}/#{config.tarball_filename(version)}"
     end


### PR DESCRIPTION
Applied changes upstream as Andrew suggested in #143 .  Now rake doesn't need to copy Ruby's lib for Rust code to work.  Don't even need a feature flag.