### PR TITLE
Add trick for 2.5.1 - DON'T MERGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
     env:
 before_install:
 - curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+- gem install bundler
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
Just a proof of concept. 
Travis should be taking care of this.
I don't understand why a simple `gem install bundler` makes 2.5.1 work.
From a conversation on twitter: https://twitter.com/6ftdan/status/979725913465282562