### PR TITLE
Relax rake dependency

### DIFF
--- a/faster_path.gemspec
+++ b/faster_path.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'bundler', '>= 1.12'
-  spec.add_dependency 'rake', '~> 12.3'
+  spec.add_dependency 'rake', '>= 12.3'
   spec.add_dependency 'thermite', '0.13.0'
   spec.add_development_dependency 'read_source', '~> 0.2.6'
   spec.add_development_dependency 'minitest', '~> 5.11'


### PR DESCRIPTION
The rake v13.0.0 already released. This fix allow to use it.
https://rubygems.org/gems/rake/versions/13.0.0

FIY: Ruby 2.7 is going to bundle v13.0.0.
https://github.com/ruby/ruby/blob/46f175ed5c8560b3c9da5ab7b4fa73287f1eb1c5/gems/bundled_gems#L5